### PR TITLE
refactored template services and routes

### DIFF
--- a/api/src/routers/org_manager.py
+++ b/api/src/routers/org_manager.py
@@ -19,7 +19,7 @@ from src.services.campaign import CampaignService
 from src.services.realm import realm_from_token
 from src.models.email_template import EmailTemplate
 from src.models.landing_page_template import LandingPageTemplate
-from src.routers import templates as templates_router
+from src.services import templates as template_service
 
 router = APIRouter()
 
@@ -124,7 +124,7 @@ async def get_realm_campaign_detail(
     tmpl = session.get(EmailTemplate, detail.email_template_id) if detail.email_template_id else None
     if tmpl and tmpl.content_link:
         try:
-            doc = await templates_router.get_template(str(tmpl.content_link))
+            doc = await template_service.get_template(str(tmpl.content_link))
             email_template = doc.model_dump()  # type: ignore[assignment]
             email_template["content_link"] = tmpl.content_link
         except Exception:
@@ -133,7 +133,7 @@ async def get_realm_campaign_detail(
     ltmpl = session.get(LandingPageTemplate, detail.landing_page_template_id) if detail.landing_page_template_id else None
     if ltmpl and ltmpl.content_link:
         try:
-            doc = await templates_router.get_template(str(ltmpl.content_link))
+            doc = await template_service.get_template(str(ltmpl.content_link))
             landing_page_template = doc.model_dump()  # type: ignore[assignment]
             landing_page_template["content_link"] = ltmpl.content_link
         except Exception:

--- a/api/src/routers/templates.py
+++ b/api/src/routers/templates.py
@@ -1,111 +1,33 @@
-from datetime import datetime
-from typing import Optional, List, Literal
+from typing import List
 
-from fastapi import APIRouter, HTTPException, status
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, status
 
-from src.core.mongo import get_templates_collection, serialize_document, to_object_id
+from src.services import templates as template_service
+from src.services.templates import TemplateCreate, TemplateUpdate, TemplateOut
 
 router = APIRouter()
 
 
-PathLiteral = Literal["/templates/emails/", "/templates/pages/"]
-
-
-class TemplateCreate(BaseModel):
-    name: str = Field(..., description="Template display name")
-    path: PathLiteral = Field(..., description="Content path to organize templates")
-    subject: str = Field(..., description="Email subject line")
-    category: Optional[str] = Field(None, description="Grouping, e.g. 'finance'")
-    description: Optional[str] = Field(None, description="Short description for UI")
-    html: str = Field(..., description="HTML content of the phishing template")
-
-
-class TemplateUpdate(BaseModel):
-    name: Optional[str] = None
-    path: Optional[PathLiteral] = None
-    subject: Optional[str] = None
-    category: Optional[str] = None
-    description: Optional[str] = None
-    html: Optional[str] = None
-
-
-class TemplateOut(TemplateCreate):
-    id: str
-    created_at: datetime
-    updated_at: datetime
-
-
 @router.get("/templates", response_model=List[TemplateOut])
 async def list_templates() -> List[TemplateOut]:
-    collection = get_templates_collection()
-    cursor = collection.find().sort("updated_at", -1)
-    results: List[TemplateOut] = []
-    async for doc in cursor:
-        results.append(TemplateOut.model_validate(serialize_document(doc)))
-    return results
+    return await template_service.list_templates()
 
 
 @router.get("/templates/{template_id}", response_model=TemplateOut)
 async def get_template(template_id: str) -> TemplateOut:
-    collection = get_templates_collection()
-    try:
-        oid = to_object_id(template_id)
-    except ValueError:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid template id")
-
-    doc = await collection.find_one({"_id": oid})
-    if not doc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
-    return TemplateOut.model_validate(serialize_document(doc))
+    return await template_service.get_template(template_id)
 
 
 @router.post("/templates", response_model=TemplateOut, status_code=status.HTTP_201_CREATED)
 async def create_template(template: TemplateCreate) -> TemplateOut:
-    collection = get_templates_collection()
-    now = datetime.utcnow()
-    payload = template.model_dump()
-    payload["created_at"] = now
-    payload["updated_at"] = now
-
-    result = await collection.insert_one(payload)
-    doc = await collection.find_one({"_id": result.inserted_id})
-    if not doc:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create template")
-    return TemplateOut.model_validate(serialize_document(doc))
+    return await template_service.create_template(template)
 
 
 @router.put("/templates/{template_id}", response_model=TemplateOut)
 async def update_template(template_id: str, template: TemplateUpdate) -> TemplateOut:
-    collection = get_templates_collection()
-    try:
-        oid = to_object_id(template_id)
-    except ValueError:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid template id")
-
-    payload = {k: v for k, v in template.model_dump().items() if v is not None}
-    if not payload:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No fields to update")
-    payload["updated_at"] = datetime.utcnow()
-
-    result = await collection.update_one({"_id": oid}, {"$set": payload})
-    if result.matched_count == 0:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
-
-    doc = await collection.find_one({"_id": oid})
-    if not doc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
-    return TemplateOut.model_validate(serialize_document(doc))
+    return await template_service.update_template(template_id, template)
 
 
 @router.delete("/templates/{template_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_template(template_id: str) -> None:
-    collection = get_templates_collection()
-    try:
-        oid = to_object_id(template_id)
-    except ValueError:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid template id")
-
-    result = await collection.delete_one({"_id": oid})
-    if result.deleted_count == 0:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    await template_service.delete_template(template_id)

--- a/api/src/services/templates.py
+++ b/api/src/services/templates.py
@@ -1,0 +1,104 @@
+from datetime import datetime
+from typing import Optional, List, Literal
+
+from fastapi import HTTPException, status
+from pydantic import BaseModel, Field
+
+from src.core.mongo import get_templates_collection, serialize_document, to_object_id
+
+
+PathLiteral = Literal["/templates/emails/", "/templates/pages/"]
+
+
+class TemplateCreate(BaseModel):
+    name: str = Field(..., description="Template display name")
+    path: PathLiteral = Field(..., description="Content path to organize templates")
+    subject: str = Field(..., description="Email subject line")
+    category: Optional[str] = Field(None, description="Grouping, e.g. 'finance'")
+    description: Optional[str] = Field(None, description="Short description for UI")
+    html: str = Field(..., description="HTML content of the phishing template")
+
+
+class TemplateUpdate(BaseModel):
+    name: Optional[str] = None
+    path: Optional[PathLiteral] = None
+    subject: Optional[str] = None
+    category: Optional[str] = None
+    description: Optional[str] = None
+    html: Optional[str] = None
+
+
+class TemplateOut(TemplateCreate):
+    id: str
+    created_at: datetime
+    updated_at: datetime
+
+
+async def list_templates() -> List[TemplateOut]:
+    collection = get_templates_collection()
+    cursor = collection.find().sort("updated_at", -1)
+    results: List[TemplateOut] = []
+    async for doc in cursor:
+        results.append(TemplateOut.model_validate(serialize_document(doc)))
+    return results
+
+
+async def get_template(template_id: str) -> TemplateOut:
+    collection = get_templates_collection()
+    try:
+        oid = to_object_id(template_id)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid template id")
+
+    doc = await collection.find_one({"_id": oid})
+    if not doc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    return TemplateOut.model_validate(serialize_document(doc))
+
+
+async def create_template(template: TemplateCreate) -> TemplateOut:
+    collection = get_templates_collection()
+    now = datetime.utcnow()
+    payload = template.model_dump()
+    payload["created_at"] = now
+    payload["updated_at"] = now
+
+    result = await collection.insert_one(payload)
+    doc = await collection.find_one({"_id": result.inserted_id})
+    if not doc:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create template")
+    return TemplateOut.model_validate(serialize_document(doc))
+
+
+async def update_template(template_id: str, template: TemplateUpdate) -> TemplateOut:
+    collection = get_templates_collection()
+    try:
+        oid = to_object_id(template_id)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid template id")
+
+    payload = {k: v for k, v in template.model_dump().items() if v is not None}
+    if not payload:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No fields to update")
+    payload["updated_at"] = datetime.utcnow()
+
+    result = await collection.update_one({"_id": oid}, {"$set": payload})
+    if result.matched_count == 0:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+
+    doc = await collection.find_one({"_id": oid})
+    if not doc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    return TemplateOut.model_validate(serialize_document(doc))
+
+
+async def delete_template(template_id: str) -> None:
+    collection = get_templates_collection()
+    try:
+        oid = to_object_id(template_id)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid template id")
+
+    result = await collection.delete_one({"_id": oid})
+    if result.deleted_count == 0:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")


### PR DESCRIPTION
This pull request refactors the template management logic in the API by moving all business logic related to templates out of the `routers/templates.py` file and into a new service layer in `services/templates.py`. This change improves code organization, separation of concerns, and reusability. It also updates other parts of the codebase to use the new service layer for template operations.

Key changes include:

**Refactoring and Code Organization:**

* Extracted all template-related business logic and Pydantic models from `routers/templates.py` into a new service module, `services/templates.py`, creating a clear separation between API routing and business logic. (`api/src/routers/templates.py` [[1]](diffhunk://#diff-55432e566b95bec930b8558e8479cd7f9455e2a634438c565672256a60482219L1-R33) `api/src/services/templates.py` [[2]](diffhunk://#diff-02a4ddce5da068c553d6154bbab200aa7d8b82e1aca1bfb2c884498a257a4e0fR1-R104)
* Updated the import statements in `routers/templates.py` and `routers/org_manager.py` to use the new `template_service` instead of directly accessing or importing routing logic. (`api/src/routers/templates.py` [[1]](diffhunk://#diff-55432e566b95bec930b8558e8479cd7f9455e2a634438c565672256a60482219L1-R33) `api/src/routers/org_manager.py` [[2]](diffhunk://#diff-4b86f2ff351909bcb1f37b57439a54b54425e823eb6269f3058b7ac0dbfda0ceL22-R22)

**API Endpoint Updates:**

* Modified all template API endpoints in `routers/templates.py` (`list_templates`, `get_template`, `create_template`, `update_template`, `delete_template`) to delegate their operations to the new service layer, simplifying the router code and ensuring consistent logic reuse. (`api/src/routers/templates.py` [api/src/routers/templates.pyL1-R33](diffhunk://#diff-55432e566b95bec930b8558e8479cd7f9455e2a634438c565672256a60482219L1-R33))
* Updated `org_manager.py` to call the new service layer for fetching templates when retrieving campaign details, ensuring all template fetching uses the new logic. (`api/src/routers/org_manager.py` [[1]](diffhunk://#diff-4b86f2ff351909bcb1f37b57439a54b54425e823eb6269f3058b7ac0dbfda0ceL127-R127) [[2]](diffhunk://#diff-4b86f2ff351909bcb1f37b57439a54b54425e823eb6269f3058b7ac0dbfda0ceL136-R136)

**Service Layer Implementation:**

* Implemented all CRUD operations and Pydantic models for templates in `services/templates.py`, including error handling and database interactions, previously found in the router. (`api/src/services/templates.py` [api/src/services/templates.pyR1-R104](diffhunk://#diff-02a4ddce5da068c553d6154bbab200aa7d8b82e1aca1bfb2c884498a257a4e0fR1-R104))