### PR TITLE
re added group creation on bulk user creation - hotifx

### DIFF
--- a/web/src/components/usergroups/newGroupFooter.tsx
+++ b/web/src/components/usergroups/newGroupFooter.tsx
@@ -28,7 +28,8 @@ function NewGroupFooter({
   isLoading,
   status
 }: NewGroupFooterProps) {
-  const isDisabled = !groupName || selectedMembersCount === 0 || isLoading;
+  // Allow creating a group without pre-selecting users; only block when no name or loading.
+  const isDisabled = !groupName || isLoading;
 
   return (
     <div className="flex flex-col gap-3 px-6 relative z-10">

--- a/web/src/services/userGroupsApi.ts
+++ b/web/src/services/userGroupsApi.ts
@@ -20,7 +20,8 @@ export async function createGroup(realm: string, name: string, token?: string) {
     body: JSON.stringify({ name }),
   });
   if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  const text = await res.text();
+  return text ? JSON.parse(text) : {};
 }
 
 export async function fetchUsers(realm: string, token?: string) {


### PR DESCRIPTION
This pull request improves group creation and bulk user import workflows, focusing on better handling of group existence, user-group assignments, and user experience. The changes ensure groups are created or reused as needed, streamline group assignment during bulk operations, and enhance UI feedback and flexibility.

**Backend group handling and upsert logic:**
- Updated `create_group_in_realm` in `realm.py` to upsert groups locally, preventing duplicate key errors by checking if a group already exists before creating a new one. The function now always returns a valid `UserGroup` object, even if group creation fails. [[1]](diffhunk://#diff-98903bd5473e9235c134fcddce216f0d24b4787f47e47a09a45283e993164885R492) [[2]](diffhunk://#diff-98903bd5473e9235c134fcddce216f0d24b4787f47e47a09a45283e993164885R507-R511) [[3]](diffhunk://#diff-98903bd5473e9235c134fcddce216f0d24b4787f47e47a09a45283e993164885L527-R533)

**Bulk user import improvements:**
- Enhanced the bulk user import process in `tenants-org-manager.tsx` to:
  - Collect all unique group names from imported users.
  - Ensure all groups exist before user creation, creating missing groups as needed.
  - Track created users and assign them to their specified groups after creation by mapping emails to user IDs and assigning each to the correct group IDs. [[1]](diffhunk://#diff-fcce0932992acf32f5fd7b66abf78cd954169821858413a086c36210d326a455R295-R351) [[2]](diffhunk://#diff-fcce0932992acf32f5fd7b66abf78cd954169821858413a086c36210d326a455R384-R439)

**UI and user experience enhancements:**
- Updated the bulk import modal to be larger and display a new "Groups" column, showing group assignments for each user. [[1]](diffhunk://#diff-fcce0932992acf32f5fd7b66abf78cd954169821858413a086c36210d326a455L810-R920) [[2]](diffhunk://#diff-fcce0932992acf32f5fd7b66abf78cd954169821858413a086c36210d326a455R951) [[3]](diffhunk://#diff-fcce0932992acf32f5fd7b66abf78cd954169821858413a086c36210d326a455R966-R970)
- Modified the new group creation footer to allow creating a group without pre-selecting users, only disabling the button when the group name is empty or loading.

**Group creation and assignment robustness:**
- Improved error handling and feedback in group creation flows, including more informative error messages and handling cases where group fetching fails after creation. [[1]](diffhunk://#diff-8de2b43a07c25667e1207e584a62ad401168f74abcef111dcbbf5afa45a86f9fR122-R152) [[2]](diffhunk://#diff-8de2b43a07c25667e1207e584a62ad401168f74abcef111dcbbf5afa45a86f9fL181-R177)
- Adjusted the group creation API response parsing to handle empty responses gracefully.