### PR TITLE
Templates refactor

### DIFF
--- a/api/src/core/security.py
+++ b/api/src/core/security.py
@@ -20,7 +20,7 @@ _JWKS_CLIENTS: dict[str, PyJWKClient] = {}
 class Resource(StrEnum):
     ADMIN = "admin"
     ORG_MANAGER = "org_manager"
-    CONTENT_MANAGER = "content-manager"
+    CONTENT_MANAGER = "content_manager"
 
 
 class Scope(StrEnum):
@@ -94,8 +94,8 @@ class Roles:
             (Resource.ADMIN.value, Scope.MANAGE.value): {"admin"},
             (Resource.ORG_MANAGER.value, Scope.VIEW.value): {"org_manager"},
             (Resource.ORG_MANAGER.value, Scope.MANAGE.value): {"org_manager"},
-            (Resource.CONTENT_MANAGER.value, Scope.VIEW.value): {"content-manager"},
-            (Resource.CONTENT_MANAGER.value, Scope.MANAGE.value): {"content-manager"},
+            (Resource.CONTENT_MANAGER.value, Scope.VIEW.value): {"content_manager"},
+            (Resource.CONTENT_MANAGER.value, Scope.MANAGE.value): {"content_manager"},
         }
 
         required_roles: set[str] = set()

--- a/api/src/core/security.py
+++ b/api/src/core/security.py
@@ -132,6 +132,7 @@ class Roles:
 
         if required_roles.isdisjoint(token_roles):
             permission_label = f"{' or '.join(self.resources)}#{self.scope}"
+            logging.error(f"403 ERROR: Token Roles: {token_roles}, Required: {required_roles}, Payload realm_access: {payload.get('realm_access')} resource_access: {payload.get('resource_access')}")
             raise HTTPException(
                 status_code=403,
                 detail=f"Permission denied for '{permission_label}'",

--- a/api/src/routers/templates.py
+++ b/api/src/routers/templates.py
@@ -3,31 +3,46 @@ from typing import List
 from fastapi import APIRouter, Depends, status
 
 from src.core.security import Roles, Resource, Scope
+from src.core.dependencies import CurrentRealm, OAuth2Scheme
+from src.services.compliance.token_helpers import decode_token_verified
 from src.services import templates as template_service
 from src.services.templates import TemplateCreate, TemplateUpdate, TemplateOut
 
 router = APIRouter()
 
+def get_org_context(token: str, realm: str) -> tuple[str, bool]:
+    claims = decode_token_verified(token)
+    roles = claims.get("realm_access", {}).get("roles", [])
+    is_content_manager = "content_manager" in roles
+    org_id = "platform" if is_content_manager else realm
+    return org_id, is_content_manager
+
+
 @router.get("/templates", dependencies=[Depends(Roles([Resource.CONTENT_MANAGER, Resource.ORG_MANAGER], Scope.VIEW))])
-async def list_templates() -> List[TemplateOut]:
-    return await template_service.list_templates()
+async def list_templates(token: OAuth2Scheme, realm: CurrentRealm) -> List[TemplateOut]:
+    org_id, is_content_manager = get_org_context(token, realm)
+    return await template_service.list_templates(org_id=org_id, include_platform=not is_content_manager)
 
 
 @router.get("/templates/{template_id}", dependencies=[Depends(Roles([Resource.CONTENT_MANAGER, Resource.ORG_MANAGER], Scope.VIEW))])
-async def get_template(template_id: str) -> TemplateOut:
-    return await template_service.get_template(template_id)
+async def get_template(template_id: str, token: OAuth2Scheme, realm: CurrentRealm) -> TemplateOut:
+    org_id, is_content_manager = get_org_context(token, realm)
+    return await template_service.get_template(template_id, org_id=org_id, can_view_platform=not is_content_manager)
 
 
-@router.post("/templates", status_code=status.HTTP_201_CREATED, dependencies=[Depends(Roles(Resource.CONTENT_MANAGER, Scope.MANAGE))])
-async def create_template(template: TemplateCreate) -> TemplateOut:
-    return await template_service.create_template(template)
+@router.post("/templates", status_code=status.HTTP_201_CREATED, dependencies=[Depends(Roles([Resource.CONTENT_MANAGER, Resource.ORG_MANAGER], Scope.MANAGE))])
+async def create_template(template: TemplateCreate, token: OAuth2Scheme, realm: CurrentRealm) -> TemplateOut:
+    org_id, _ = get_org_context(token, realm)
+    return await template_service.create_template(template, org_id=org_id)
 
 
-@router.put("/templates/{template_id}", dependencies=[Depends(Roles(Resource.CONTENT_MANAGER, Scope.MANAGE))])
-async def update_template(template_id: str, template: TemplateUpdate) -> TemplateOut:
-    return await template_service.update_template(template_id, template)
+@router.put("/templates/{template_id}", dependencies=[Depends(Roles([Resource.CONTENT_MANAGER, Resource.ORG_MANAGER], Scope.MANAGE))])
+async def update_template(template_id: str, template: TemplateUpdate, token: OAuth2Scheme, realm: CurrentRealm) -> TemplateOut:
+    org_id, _ = get_org_context(token, realm)
+    return await template_service.update_template(template_id, template, org_id=org_id)
 
 
-@router.delete("/templates/{template_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(Roles(Resource.CONTENT_MANAGER, Scope.MANAGE))])
-async def delete_template(template_id: str) -> None:
-    await template_service.delete_template(template_id)
+@router.delete("/templates/{template_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(Roles([Resource.CONTENT_MANAGER, Resource.ORG_MANAGER], Scope.MANAGE))])
+async def delete_template(template_id: str, token: OAuth2Scheme, realm: CurrentRealm) -> None:
+    org_id, _ = get_org_context(token, realm)
+    await template_service.delete_template(template_id, org_id=org_id)

--- a/api/src/services/modules.py
+++ b/api/src/services/modules.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from bson import ObjectId
 from bson.errors import InvalidId
+from pymongo import ReturnDocument
 from fastapi import HTTPException, status
 
 from src.core.mongo import get_modules_collection
@@ -139,19 +140,23 @@ async def update_module(module_id: str, payload: ModuleUpdate, realm: str) -> Mo
     oid = _to_object_id(module_id)
     col = get_modules_collection()
 
-    existing = await col.find_one({"_id": oid, "realm": realm})
-    if existing is None:
+    data = payload.model_dump()
+    # We must explicitly look up existing version or default to 1 for atomic bump?
+    # Actually wait, we can do $inc for version! Let's just do it directly.
+    data["updated_at"] = _now()
+    
+    updated = await col.find_one_and_update(
+        {"_id": oid, "realm": realm},
+        {
+            "$set": data,
+            "$inc": {"version": 1}
+        },
+        return_document=ReturnDocument.AFTER
+    )
+    if updated is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=MODULE_NOT_FOUND)
 
-    data = payload.model_dump()
-    data.update(
-        updated_at=_now(),
-        version=existing.get("version", 1) + 1,
-    )
-
-    await col.update_one({"_id": oid}, {"$set": data})
-    updated = await col.find_one({"_id": oid})
-    return _doc_to_out(updated)  # type: ignore[arg-type]
+    return _doc_to_out(updated)
 
 
 async def patch_module(module_id: str, payload: ModulePatch, realm: str) -> ModuleOut:
@@ -159,22 +164,27 @@ async def patch_module(module_id: str, payload: ModulePatch, realm: str) -> Modu
     oid = _to_object_id(module_id)
     col = get_modules_collection()
 
-    existing = await col.find_one({"_id": oid, "realm": realm})
-    if existing is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=MODULE_NOT_FOUND)
-
-    # Only include fields that were explicitly provided (exclude_unset)
     delta = payload.model_dump(exclude_unset=True)
     if not delta:
-        # Nothing to change — return as-is to avoid a spurious DB round-trip
+        existing = await col.find_one({"_id": oid, "realm": realm})
+        if existing is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=MODULE_NOT_FOUND)
         return _doc_to_out(existing)
 
     delta["updated_at"] = _now()
-    delta["version"]    = existing.get("version", 1) + 1
 
-    await col.update_one({"_id": oid}, {"$set": delta})
-    updated = await col.find_one({"_id": oid})
-    return _doc_to_out(updated)  # type: ignore[arg-type]
+    updated = await col.find_one_and_update(
+        {"_id": oid, "realm": realm},
+        {
+            "$set": delta,
+            "$inc": {"version": 1}
+        },
+        return_document=ReturnDocument.AFTER
+    )
+    if updated is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=MODULE_NOT_FOUND)
+
+    return _doc_to_out(updated)
 
 
 async def delete_module(module_id: str, realm: str) -> None:
@@ -182,8 +192,6 @@ async def delete_module(module_id: str, realm: str) -> None:
     oid = _to_object_id(module_id)
     col = get_modules_collection()
 
-    existing = await col.find_one({"_id": oid, "realm": realm})
-    if existing is None:
+    deleted = await col.find_one_and_delete({"_id": oid, "realm": realm})
+    if deleted is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=MODULE_NOT_FOUND)
-
-    await col.delete_one({"_id": oid})

--- a/api/src/services/platform_admin/realm_handler.py
+++ b/api/src/services/platform_admin/realm_handler.py
@@ -46,6 +46,22 @@ class realm_handler:
             features=realm.features,
         )
 
+        try:
+            token = self.admin._get_admin_token()
+            users = self.admin.list_users(realm.name)
+            org_manager_user = next((u for u in users if str(u.get("username")).lower() == "org_manager"), None)
+            if org_manager_user:
+                client = self.admin.keycloak_client.get_client_by_client_id(realm.name, token, "realm-management")
+                if client:
+                    client_id = client.get("id")
+                    client_role = self.admin.keycloak_client.get_client_role(realm.name, token, client_id, "realm-admin")
+                    if client_role:
+                        self.admin.keycloak_client.assign_client_roles(
+                            realm.name, token, org_manager_user.get("id"), client_id, [client_role]
+                        )
+        except Exception as e:
+            print(f"Warning: Failed to bootstrap ORG_MANAGER with realm-admin: {e}")
+
         self._ensure_realm(session, realm.name, normalized_domain)
 
         

--- a/api/src/services/sending_profile.py
+++ b/api/src/services/sending_profile.py
@@ -57,6 +57,8 @@ class SendingProfileService:
             raise ValueError("Server disconnected unexpectedly")
         except TimeoutError:
             raise ValueError("Connection timed out")
+        except OSError as e:
+            raise ValueError(f"Network error: {e}")
         except Exception as e:
             raise RuntimeError(str(e))
 

--- a/api/src/services/templates.py
+++ b/api/src/services/templates.py
@@ -3,7 +3,9 @@ from datetime import datetime
 from typing import Optional, List, Literal, Dict, Any
 
 from fastapi import HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from pymongo import ReturnDocument
 
 from src.core.mongo import get_templates_collection, serialize_document, to_object_id
 
@@ -31,13 +33,28 @@ def render_template(html: str, variables: Dict[str, Any]) -> str:
     return pattern.sub(replace, html)
 
 
-class TemplateCreate(BaseModel):
+class TemplateBase(BaseModel):
     name: str = Field(..., description="Template display name")
     path: PathLiteral = Field(..., description="Content path to organize templates")
-    subject: str = Field(..., description="Email subject line")
+    subject: Optional[str] = Field(None, description="Email subject line")
     category: Optional[str] = Field(None, description="Grouping, e.g. 'finance'")
     description: Optional[str] = Field(None, description="Short description for UI")
     html: str = Field(..., description="HTML content of the phishing template")
+
+class TemplateCreate(TemplateBase):
+
+    @model_validator(mode='after')
+    def validate_template_requirements(self) -> 'TemplateCreate':
+        if self.path == "/templates/emails/":
+            if not self.subject or not self.subject.strip():
+                raise ValueError("Email templates must have a subject line.")
+            if "${{redirect}}" not in self.html or "${{pixel}}" not in self.html:
+                raise ValueError("Email templates must include both ${{redirect}} and ${{pixel}}.")
+        elif self.path == "/templates/pages/":
+            if "${{redirect}}" not in self.html:
+                raise ValueError("Landing page templates must include the ${{redirect}} variable.")
+            self.subject = None
+        return self
 
 
 class TemplateUpdate(BaseModel):
@@ -48,23 +65,51 @@ class TemplateUpdate(BaseModel):
     description: Optional[str] = None
     html: Optional[str] = None
 
+    @model_validator(mode='after')
+    def validate_template_requirements(self) -> 'TemplateUpdate':
+        if self.path == "/templates/emails/":
+            if self.subject is not None and not self.subject.strip():
+                raise ValueError("Email templates must have a valid subject line.")
+            if self.html is not None:
+                if "${{redirect}}" not in self.html or "${{pixel}}" not in self.html:
+                    raise ValueError("Email templates must include both ${{redirect}} and ${{pixel}}.")
+        elif self.path == "/templates/pages/":
+            if self.html is not None and "${{redirect}}" not in self.html:
+                raise ValueError("Landing page templates must include the ${{redirect}} variable.")
+            self.subject = None
+        return self
 
-class TemplateOut(TemplateCreate):
+
+class TemplateOut(TemplateBase):
     id: str
+    org_id: str = "platform"
     created_at: datetime
     updated_at: datetime
 
 
-async def list_templates() -> List[TemplateOut]:
+async def list_templates(org_id: str, include_platform: bool = False) -> List[TemplateOut]:
     collection = get_templates_collection()
-    cursor = collection.find().sort("updated_at", -1)
+    
+    platform_conds = [{"org_id": "platform"}, {"org_id": {"$exists": False}}, {"org_id": None}]
+    
+    if org_id == "platform":
+        query = {"$or": platform_conds}
+    else:
+        query = {"org_id": org_id}
+        if include_platform:
+            query = {"$or": [{"org_id": org_id}] + platform_conds}
+            
+    cursor = collection.find(query).sort("updated_at", -1)
     results: List[TemplateOut] = []
     async for doc in cursor:
-        results.append(TemplateOut.model_validate(serialize_document(doc)))
+        doc_dict = serialize_document(doc)
+        if "org_id" not in doc_dict or not doc_dict["org_id"]:
+            doc_dict["org_id"] = "platform"
+        results.append(TemplateOut.model_validate(doc_dict))
     return results
 
 
-async def get_template(template_id: str) -> TemplateOut:
+async def get_template(template_id: str, org_id: str, can_view_platform: bool = False) -> TemplateOut:
     collection = get_templates_collection()
     try:
         oid = to_object_id(template_id)
@@ -74,13 +119,23 @@ async def get_template(template_id: str) -> TemplateOut:
     doc = await collection.find_one({"_id": oid})
     if not doc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
-    return TemplateOut.model_validate(serialize_document(doc))
+        
+    doc_dict = serialize_document(doc)
+    doc_org_id = doc_dict.get("org_id") or "platform"
+    doc_dict["org_id"] = doc_org_id
+    
+    if doc_org_id != org_id:
+        if not (can_view_platform and doc_org_id == "platform"):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to view this template")
+
+    return TemplateOut.model_validate(doc_dict)
 
 
-async def create_template(template: TemplateCreate) -> TemplateOut:
+async def create_template(template: TemplateCreate, org_id: str) -> TemplateOut:
     collection = get_templates_collection()
     now = datetime.utcnow()
     payload = template.model_dump()
+    payload["org_id"] = org_id
     payload["created_at"] = now
     payload["updated_at"] = now
 
@@ -88,39 +143,65 @@ async def create_template(template: TemplateCreate) -> TemplateOut:
     doc = await collection.find_one({"_id": result.inserted_id})
     if not doc:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create template")
-    return TemplateOut.model_validate(serialize_document(doc))
+        
+    doc_dict = serialize_document(doc)
+    doc_dict["org_id"] = org_id
+    return TemplateOut.model_validate(doc_dict)
 
 
-async def update_template(template_id: str, template: TemplateUpdate) -> TemplateOut:
+async def update_template(template_id: str, template: TemplateUpdate, org_id: str) -> TemplateOut:
     collection = get_templates_collection()
     try:
         oid = to_object_id(template_id)
     except ValueError:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid template id")
-
+        
     payload = {k: v for k, v in template.model_dump().items() if v is not None}
     if not payload:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No fields to update")
     payload["updated_at"] = datetime.utcnow()
 
-    result = await collection.update_one({"_id": oid}, {"$set": payload})
-    if result.matched_count == 0:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    filter_q: Dict[str, Any] = {"_id": oid}
+    if org_id == "platform":
+        filter_q["$or"] = [{"org_id": "platform"}, {"org_id": {"$exists": False}}, {"org_id": None}]
+    else:
+        filter_q["org_id"] = org_id
 
-    doc = await collection.find_one({"_id": oid})
+    doc = await collection.find_one_and_update(
+        filter_q,
+        {"$set": payload},
+        return_document=ReturnDocument.AFTER
+    )
+    
     if not doc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
-    return TemplateOut.model_validate(serialize_document(doc))
+        # Fallback to check if it's 404 or 403
+        existing = await collection.find_one({"_id": oid})
+        if not existing:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to edit this template")
+        
+    doc_dict = serialize_document(doc)
+    doc_dict["org_id"] = doc_dict.get("org_id") or "platform"
+    return TemplateOut.model_validate(doc_dict)
 
 
-async def delete_template(template_id: str) -> None:
+async def delete_template(template_id: str, org_id: str) -> None:
     collection = get_templates_collection()
     try:
         oid = to_object_id(template_id)
     except ValueError:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid template id")
 
-    result = await collection.delete_one({"_id": oid})
-    if result.deleted_count == 0:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    filter_q: Dict[str, Any] = {"_id": oid}
+    if org_id == "platform":
+        filter_q["$or"] = [{"org_id": "platform"}, {"org_id": {"$exists": False}}, {"org_id": None}]
+    else:
+        filter_q["org_id"] = org_id
+
+    deleted = await collection.find_one_and_delete(filter_q)
+    if not deleted:
+        existing = await collection.find_one({"_id": oid})
+        if not existing:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to delete this template")
 

--- a/deployment/docker-compose.dev.yml
+++ b/deployment/docker-compose.dev.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - db_data:/var/lib/postgresql
+      - db_data:/var/lib/postgresql/data
       - ../db/init-dbs.sql:/docker-entrypoint-initdb.d/init-dbs.sql
 
     healthcheck:
@@ -136,6 +136,7 @@ services:
       CLIENT_SECRET: ${CLIENT_SECRET}
       WEB_URL: ${WEB_URL}
       API_URL: ${API_URL}
+      JAVA_OPTS_APPEND: "-Dkeycloak.migration.strategy=IGNORE_EXISTING"
 
     healthcheck:
       test:
@@ -159,6 +160,7 @@ services:
       - ../keycloak/themes:/opt/keycloak/themes:ro
       - ../keycloak/imports:/opt/keycloak/data/import:ro
       - ../keycloak/providers:/opt/keycloak/providers:ro
+      - keycloak_data:/opt/keycloak/data
 
   api:
     build:
@@ -240,3 +242,4 @@ volumes:
   rabbitmq_data:
   mongo_data:
   garage_data:
+  keycloak_data:

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     expose:
       - "5432"
     volumes:
-      - db_data:/var/lib/postgresql
+      - db_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 10s
@@ -160,6 +160,7 @@ services:
       KC_DB_URL: jdbc:postgresql://db:5432/keycloak
       KC_DB_USERNAME: ${POSTGRES_USER}
       KC_DB_PASSWORD: ${POSTGRES_PASSWORD}
+      CLIENT_SECRET: ${CLIENT_SECRET}
 
       KC_HTTP_ENABLED: "true"
       KC_HOSTNAME_BACKCHANNEL_DYNAMIC: "false"
@@ -168,9 +169,9 @@ services:
       KC_HOSTNAME_STRICT: "false"
       KC_HEALTH_ENABLED: "true"
 
-      CLIENT_SECRET: ${CLIENT_SECRET}
       WEB_URL: ${WEB_URL}
       API_URL: ${API_URL}
+      JAVA_OPTS_APPEND: "-Dkeycloak.migration.strategy=IGNORE_EXISTING"
     healthcheck:
       test: ["CMD", "true"]
       interval: 30s
@@ -182,6 +183,9 @@ services:
     depends_on:
       db:
         condition: service_healthy
+
+    volumes:
+      - keycloak_data:/opt/keycloak/data
 
   api:
     build:
@@ -270,3 +274,4 @@ volumes:
   garage_data:
   rabbitmq_data:
   mongo_data:
+  keycloak_data:

--- a/keycloak/imports/realm-export.json
+++ b/keycloak/imports/realm-export.json
@@ -80,6 +80,7 @@
         "enabled": true,
         "publicClient": true,
         "redirectUris": [
+          "${WEB_URL}/*",
           "${WEB_URL}/admin/*",
           "${WEB_URL}/content-manager/*"
         ],

--- a/web/src/Pages/templates.tsx
+++ b/web/src/Pages/templates.tsx
@@ -1,13 +1,15 @@
 import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Plus, Eye, Layout } from "lucide-react";
-import { apiClient } from "@/lib/api-client";
+import { Plus } from "lucide-react";
+import { toast } from "sonner";
+import { templateApi } from "@/services/templateApi";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import DisplayModeToggle from "@/components/shared/DisplayModeToggle";
 import RefreshButton from "@/components/shared/RefreshButton";
 import SearchBar from "@/components/shared/SearchBar";
+import { TemplateCard } from "@/components/templates/TemplateCard";
 import { TemplateFormModal } from "@/components/templates/TemplateFormModal";
 import { TemplatePreviewModal } from "@/components/templates/TemplatePreviewModal";
 import { LoadingGrid } from "@/components/templates/LoadingGrid";
@@ -22,7 +24,6 @@ type ViewMode = "grid" | "table";
 const templateMatchesQuery = (template: Template, query: string) => {
   const haystack = [
     template.name,
-    template.subject,
     template.description,
     template.category
   ]
@@ -38,13 +39,14 @@ export default function TemplatesPage() {
     Template[]
   >({
     queryKey: ["templates"],
-    queryFn: () => apiClient.get<Template[]>("/templates"),
+    queryFn: () => templateApi.getTemplates(),
     staleTime: 30_000
   });
   const qc = useQueryClient();
 
   const [previewId, setPreviewId] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
+  const [editingTemplate, setEditingTemplate] = useState<Template | null>(null);
   const [form, setForm] = useState(initialTemplateForm);
   const [activeTab, setActiveTab] =
     useState<(typeof templatePaths)[number]>("/templates/emails/");
@@ -54,7 +56,9 @@ export default function TemplatesPage() {
   const templates = useMemo(() => data ?? [], [data]);
   const { keycloak } = useKeycloak();
   const userRoles = keycloak.tokenParsed?.realm_access?.roles ?? [];
-  const isContentManager = userRoles.includes("CONTENT_MANAGER");
+  const isContentManager = userRoles.includes("content_manager") || userRoles.includes("CONTENT_MANAGER");
+  const isOrgManager = userRoles.includes("org_manager") || userRoles.includes("ORG_MANAGER");
+  const canManageTemplates = isContentManager || isOrgManager;
   const grouped = useMemo(() => {
     return templates.reduce<Record<string, Template[]>>(
       (acc, t) => {
@@ -78,153 +82,12 @@ export default function TemplatesPage() {
     ) as Record<string, Template[]>;
   }, [grouped, searchQuery]);
 
-  const renderTemplateCard = (template: Template, isEmail: boolean) => {
-    if (viewMode === "table") {
-      return (
-        <div
-          key={template.id}
-          className="flex items-center gap-3 px-4 py-3 rounded-md border border-border bg-background"
-        >
-          <div className="h-9 w-9 rounded-md bg-primary/10 flex items-center justify-center shrink-0">
-            {isEmail ? (
-              <Eye className="h-4 w-4 text-primary" />
-            ) : (
-              <Layout className="h-4 w-4 text-primary" />
-            )}
-          </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-foreground truncate">
-              {template.name}
-            </p>
-            <p className="text-xs text-muted-foreground truncate">
-              {template.subject || template.description || "No description"}
-            </p>
-            <p className="text-[11px] text-muted-foreground mt-0.5">
-              Updated {new Date(template.updated_at).toLocaleDateString()}
-            </p>
-          </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="gap-1.5 h-8 text-xs shrink-0"
-            onClick={() => setPreviewId(template.id)}
-          >
-            <Eye className="h-3.5 w-3.5" />
-            Preview
-          </Button>
-        </div>
-      );
-    }
-
-    if (isEmail) {
-      return (
-        <div
-          key={template.id}
-          className="relative border-2 rounded-lg bg-background overflow-hidden transition-all duration-200 text-left w-full hover:border-primary/50 hover:shadow-sm border-border"
-        >
-          <div className="border-b border-border/50 bg-muted/20 px-3 py-2.5">
-            <p className="text-sm font-medium text-foreground truncate pr-8">
-              {template.name}
-            </p>
-          </div>
-          <div className="p-3">
-            {template.subject && template.subject !== template.name && (
-              <p className="text-xs text-primary/80 truncate">
-                {template.subject}
-              </p>
-            )}
-            {template.description && (
-              <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
-                {template.description}
-              </p>
-            )}
-            <p className="text-[11px] text-muted-foreground mt-2">
-              Updated {new Date(template.updated_at).toLocaleDateString()}
-            </p>
-            <div className="mt-3">
-              <Button
-                variant="outline"
-                size="sm"
-                className="gap-1.5 h-8 text-xs"
-                onClick={() => setPreviewId(template.id)}
-              >
-                <Eye className="h-3.5 w-3.5" />
-                Preview
-              </Button>
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    return (
-      <div
-        key={template.id}
-        className="relative border-2 rounded-lg bg-background overflow-hidden transition-all duration-200 text-left w-full hover:border-primary/50 hover:shadow-sm border-border group"
-      >
-        <div className="w-full h-32 bg-muted/30 border-b border-border/50 relative overflow-hidden">
-          {template.html ? (
-            <iframe
-              title={`thumb-${template.id}`}
-              srcDoc={template.html}
-              sandbox=""
-              className="pointer-events-none"
-              style={{
-                width: "200%",
-                height: "200%",
-                transform: "scale(0.5)",
-                transformOrigin: "top left",
-                border: 0
-              }}
-            />
-          ) : (
-            <div className="flex items-center justify-center h-full">
-              <Layout className="h-10 w-10 text-muted-foreground/30" />
-            </div>
-          )}
-
-          <button
-            type="button"
-            onClick={() => setPreviewId(template.id)}
-            className="absolute bottom-2 right-2 flex items-center gap-1 px-2 py-1 rounded-md bg-background/90 border border-border/60 text-xs text-foreground/80 opacity-0 group-hover:opacity-100 transition-opacity hover:bg-background hover:text-foreground"
-          >
-            <Eye className="h-3 w-3" />
-            Preview
-          </button>
-        </div>
-        <div className="p-3">
-          <p className="text-sm font-medium text-foreground truncate">
-            {template.name}
-          </p>
-          {template.subject && template.subject !== template.name && (
-            <p className="text-xs text-primary/80 truncate mt-0.5">
-              {template.subject}
-            </p>
-          )}
-          {template.description && (
-            <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
-              {template.description}
-            </p>
-          )}
-          <p className="text-[11px] text-muted-foreground mt-2">
-            Updated {new Date(template.updated_at).toLocaleDateString()}
-          </p>
-        </div>
-      </div>
-    );
-  };
-
-  const previewTemplate = useMemo(
-    () => templates.find((t) => t.id === previewId),
-    [previewId, templates]
-  );
-
   const createTemplate = useMutation({
     mutationFn: () =>
-      apiClient.post<Template>("/templates", {
+      templateApi.createTemplate({
         name: form.name,
         path: form.path,
-        subject: form.subject,
+        subject: form.path === "/templates/emails/" ? form.subject : undefined,
         category: form.category || null,
         description: form.description || null,
         html: form.html
@@ -233,16 +96,79 @@ export default function TemplatesPage() {
       qc.invalidateQueries({ queryKey: ["templates"] });
       setForm(initialTemplateForm);
       setShowForm(false);
-    }
+      toast.success("Template created successfully");
+    },
+    onError: () => toast.error("Failed to create template")
+  });
+
+  const updateTemplate = useMutation({
+    mutationFn: (data: { id: string; payload: Partial<Template> }) =>
+      templateApi.updateTemplate(data.id, data.payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["templates"] });
+      setForm(initialTemplateForm);
+      setEditingTemplate(null);
+      setShowForm(false);
+      toast.success("Template updated successfully");
+    },
+    onError: () => toast.error("Failed to update template")
+  });
+
+  const deleteTemplate = useMutation({
+    mutationFn: (id: string) => templateApi.deleteTemplate(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["templates"] });
+      toast.success("Template deleted successfully");
+    },
+    onError: () => toast.error("Failed to delete template")
   });
 
   const openCreateModal = () => {
+    setEditingTemplate(null);
     setForm({ ...initialTemplateForm, path: activeTab });
     setShowForm(true);
   };
 
+  const openEditModal = (template: Template) => {
+    setEditingTemplate(template);
+    setForm({
+      name: template.name,
+      path: template.path,
+      subject: template.subject || "",
+      category: template.category || "",
+      description: template.description || "",
+      html: template.html || ""
+    });
+    setShowForm(true);
+  };
+
+  const handleDelete = (template: Template) => {
+    if (confirm(`Are you sure you want to delete the template "${template.name}"?`)) {
+      deleteTemplate.mutate(template.id);
+    }
+  };
+
+  const previewTemplate = useMemo(
+    () => templates.find((t) => t.id === previewId),
+    [previewId, templates]
+  );
+
   const saveTemplate = () => {
-    createTemplate.mutate();
+    if (editingTemplate) {
+      updateTemplate.mutate({
+        id: editingTemplate.id,
+        payload: {
+          name: form.name,
+          path: form.path,
+          subject: form.path === "/templates/emails/" ? form.subject : undefined,
+          category: form.category || null,
+          description: form.description || null,
+          html: form.html
+        }
+      });
+    } else {
+      createTemplate.mutate();
+    }
   };
 
   return (
@@ -257,7 +183,7 @@ export default function TemplatesPage() {
           </p>
         </div>
         <div className="flex items-center gap-3">
-          {isContentManager && (
+          {canManageTemplates && (
             <Button
               className="inline-flex items-center gap-2 text-white border-0 transition-colors bg-primary hover:bg-primary/90"
               onClick={openCreateModal}
@@ -272,15 +198,19 @@ export default function TemplatesPage() {
       {isLoading && <LoadingGrid />}
 
       {/* 3. Protect the Form Modal (prevent manual state triggering) */}
-      {showForm && isContentManager && (
+      {showForm && canManageTemplates && (
         <TemplateFormModal
           showForm={showForm}
-          editingTemplate={null}
+          editingTemplate={editingTemplate}
           form={form}
           setForm={setForm}
-          onClose={() => setShowForm(false)}
+          onClose={() => {
+            setShowForm(false);
+            setEditingTemplate(null);
+            setForm(initialTemplateForm);
+          }}
           onSave={saveTemplate}
-          isSaving={createTemplate.isPending}
+          isSaving={editingTemplate ? updateTemplate.isPending : createTemplate.isPending}
         />
       )}
 
@@ -360,9 +290,18 @@ export default function TemplatesPage() {
                             : "space-y-2"
                         )}
                       >
-                        {bucket.map((template) =>
-                          renderTemplateCard(template, isEmail)
-                        )}
+                        {bucket.map((template) => (
+                          <TemplateCard
+                            key={template.id}
+                            template={template}
+                            isEmail={isEmail}
+                            layout={viewMode === "grid" ? "grid" : "list"}
+                            onPreview={() => setPreviewId(template.id)}
+                            onEdit={canManageTemplates ? () => openEditModal(template) : undefined}
+                            onDelete={canManageTemplates ? () => handleDelete(template) : undefined}
+                            deleting={deleteTemplate.isPending}
+                          />
+                        ))}
                       </div>
                     )}
                   </TabsContent>

--- a/web/src/components/phishing-kits/PhishingKitEditPage.tsx
+++ b/web/src/components/phishing-kits/PhishingKitEditPage.tsx
@@ -4,8 +4,7 @@ import { useKeycloak } from "@react-keycloak/web";
 import { Loader2 } from "lucide-react";
 import { fetchPhishingKit } from "@/services/phishingKitsApi";
 import { fetchSendingProfiles } from "@/services/sendingProfilesApi";
-import type { Template } from "@/components/templates/types";
-import { apiClient } from "@/lib/api-client";
+import { templateApi } from "@/services/templateApi";
 import PhishingKitForm from "./PhishingKitForm";
 
 interface PhishingKitEditPageProps {
@@ -28,7 +27,7 @@ export default function PhishingKitEditPage({
     isError: templatesError
   } = useQuery({
     queryKey: ["templates"],
-    queryFn: () => apiClient.get<Template[]>("/templates")
+    queryFn: () => templateApi.getTemplates()
   });
 
   const {

--- a/web/src/components/phishing-kits/TemplatePicker.tsx
+++ b/web/src/components/phishing-kits/TemplatePicker.tsx
@@ -16,7 +16,7 @@ import SearchBar from "@/components/shared/SearchBar";
 import { cn } from "@/lib/utils";
 import type { Template } from "@/components/templates/types";
 import { TemplatePreviewModal } from "@/components/templates/TemplatePreviewModal";
-import { apiClient } from "@/lib/api-client";
+import { templateApi } from "@/services/templateApi";
 import { toast } from "sonner";
 
 type ViewMode = "grid" | "list";
@@ -67,9 +67,6 @@ function EmailTemplateGridCard({
 
       {/* Info */}
       <div className="p-3">
-        {template.subject && template.subject !== template.name && (
-          <p className="text-xs text-primary/80 truncate">{template.subject}</p>
-        )}
         {template.description && (
           <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
             {template.description}
@@ -165,11 +162,6 @@ function LandingPageTemplateGridCard({
         <p className="text-sm font-medium text-foreground truncate">
           {template.name}
         </p>
-        {template.subject && template.subject !== template.name && (
-          <p className="text-xs text-primary/80 truncate mt-0.5">
-            {template.subject}
-          </p>
-        )}
         {template.description && (
           <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
             {template.description}
@@ -220,7 +212,7 @@ function TemplateListRow({
           {template.name}
         </p>
         <p className="text-xs text-muted-foreground truncate">
-          {template.subject || template.description || "No description"}
+          {template.description || "No description"}
         </p>
       </div>
 
@@ -288,7 +280,7 @@ export default function TemplatePicker({
     setIsLoading(true);
     setError(null);
     try {
-      const all = await apiClient.get<Template[]>("/templates");
+      const all = await templateApi.getTemplates();
       setTemplates(all.filter((t) => t.path === templatePath));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load templates");
@@ -306,8 +298,7 @@ export default function TemplatePicker({
     return templates.filter(
       (t) =>
         t.name.toLowerCase().includes(q) ||
-        (t.description ?? "").toLowerCase().includes(q) ||
-        (t.subject ?? "").toLowerCase().includes(q)
+        (t.description ?? "").toLowerCase().includes(q)
     );
   }, [templates, searchQuery]);
 

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from "@tanstack/react-router";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { useKeycloak } from "@react-keycloak/web";
 import { PanelLeftClose, PanelLeftOpen, ChevronDown } from "lucide-react";
 import {
@@ -155,23 +155,21 @@ export function Sidebar() {
     sourceLinks = contentManagerLinks;
     routePrefix = "/content-manager";
   }
+  
+  const [initDone, setInitDone] = useState(false);
 
-  // Filter and group
-  const visibleLinks = filterLinks(sourceLinks, userRoles, realmFeatures);
-  const { dashboard, groups, standalone } = groupNavigationLinks(visibleLinks);
-
-  const currentActiveGroupLabel =
-    groups.find((group) =>
-      group.links.some((link) => location.pathname.startsWith(link.href))
-    )?.label ?? null;
+  const visibleLinks = useMemo(() => filterLinks(sourceLinks, userRoles, realmFeatures), [sourceLinks, userRoles, realmFeatures]);
+  const { dashboard, groups, standalone } = useMemo(() => groupNavigationLinks(visibleLinks), [visibleLinks]);
 
   useEffect(() => {
-    if (openGroupKey && groups.some((group) => group.label === openGroupKey)) {
-      return;
+    if (!initDone) {
+      const activeGroup = groups.find((group: any) =>
+        group.links.some((link: NavLinkDef) => location.pathname.startsWith(link.href))
+      )?.label;
+      setOpenGroupKey(activeGroup ?? groups[0]?.label ?? null);
+      setInitDone(true);
     }
-
-    setOpenGroupKey(currentActiveGroupLabel ?? groups[0]?.label ?? null);
-  }, [currentActiveGroupLabel, groups, openGroupKey]);
+  }, [groups, location.pathname, initDone]);
 
   // Adjust footer links with route prefix if they aren't absolute
   const activeFooterLinks = footerLinks.map((link) => ({
@@ -212,7 +210,7 @@ export function Sidebar() {
             </li>
           )}
 
-          {groups.map((group) => (
+          {groups.map((group: any) => (
             <SidebarGroup
               key={group.label}
               {...group}
@@ -226,7 +224,7 @@ export function Sidebar() {
             />
           ))}
 
-          {standalone.map((link) => (
+          {standalone.map((link: NavLinkDef) => (
             <li key={link.href}>
               <SidebarLink {...link} isCollapsed={!expanded} />
             </li>

--- a/web/src/components/templates/TemplateCard.tsx
+++ b/web/src/components/templates/TemplateCard.tsx
@@ -1,68 +1,123 @@
-import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Eye, Pencil, Trash2 } from "lucide-react";
-import type { Template } from "./types";
+import { Edit2, Eye, Trash2, Layout, Mail } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { Template } from './types'
+
+function ActionButton({
+    onClick,
+    icon: Icon,
+    title,
+    variant = 'default',
+    disabled = false
+}: {
+    onClick: () => void,
+    icon: any,
+    title: string,
+    variant?: 'default' | 'danger',
+    disabled?: boolean
+}) {
+    return (
+        <button
+            disabled={disabled}
+            onClick={(e) => {
+                e.preventDefault();
+                onClick();
+            }}
+            className={cn(
+                "p-1.5 rounded-lg border border-border/50 text-muted-foreground transition-all shadow-sm bg-background",
+                variant === 'danger'
+                    ? "hover:text-red-500 hover:bg-red-50 hover:border-red-200"
+                    : "hover:text-primary hover:bg-primary/5 hover:border-primary/20",
+                disabled && "opacity-50 cursor-not-allowed hover:bg-background hover:border-border/50 hover:text-muted-foreground"
+            )}
+            title={title}
+        >
+            <Icon size={14} />
+        </button>
+    )
+}
 
 interface Props {
   readonly template: Template;
-  readonly excerpt: string;
-  readonly onPreview: () => void;
-  readonly onEdit: () => void;
-  readonly onDelete: () => void;
-  readonly deleting: boolean;
+  readonly isEmail?: boolean;
+  readonly layout?: 'grid' | 'list';
+  readonly onPreview?: () => void;
+  readonly onEdit?: () => void;
+  readonly onDelete?: () => void;
+  readonly deleting?: boolean;
 }
 
-export function TemplateCard({ template, excerpt, onPreview, onEdit, onDelete, deleting }: Props) {
-  const updated = new Date(template.updated_at).toLocaleString();
+export function TemplateCard({ template, isEmail = true, layout = 'grid', onPreview, onEdit, onDelete, deleting = false }: Props) {
+    const isList = layout === 'list'
+    const updatedDate = new Date(template.updated_at).toLocaleDateString()
 
-  return (
-    <Card className="bg-background/90 hover:shadow-lg transition-shadow">
-      <CardHeader className="space-y-2">
-        <CardTitle className="flex items-center gap-2 text-foreground">
-          {template.name}
-        </CardTitle>
-        <CardDescription className="text-muted-foreground">{template.subject}</CardDescription>
-        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-          {template.category && (
-            <span className="rounded-full bg-primary/10 px-3 py-1 text-primary border border-purple-100">
-              {template.category}
-            </span>
-          )}
-          <span className="rounded-full bg-muted px-3 py-1">{updated}</span>
+    return (
+        <div
+            className={cn(
+                "group relative flex bg-background border border-border rounded-xl overflow-hidden shadow-sm hover:shadow-lg transition-all duration-300",
+                isList ? "flex-row flex-wrap sm:flex-nowrap items-center min-h-[5rem]" : "flex-col",
+            )}
+        >
+            {/* Content Section */}
+            <div className={cn("flex flex-col flex-1 gap-2 min-w-0 w-full", isList ? "px-5 py-3" : "p-5")}>
+                <div className={cn("flex justify-between items-start", isList && "items-center")}>
+                    <div className="flex items-center gap-3 w-full">
+                        {isList && (
+                            <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center shrink-0 hidden sm:flex">
+                                {isEmail ? <Mail className="h-5 w-5 text-primary/70" /> : <Layout className="h-5 w-5 text-primary/70" />}
+                            </div>
+                        )}
+                        <div className="min-w-0 flex-1">
+                            <h3 className={cn(
+                                "font-semibold text-foreground group-hover:text-primary transition-colors leading-snug",
+                                isList ? "text-base truncate" : "text-sm line-clamp-1"
+                            )}>
+                                {template.name}
+                            </h3>
+                        </div>
+                    </div>
+                    {/* Category Badge */}
+                    {!isList && template.category && (
+                        <span className="px-2 py-0.5 bg-primary/10 rounded-full text-[10px] font-bold uppercase tracking-wider text-primary border border-primary/20 ml-2 shrink-0">
+                            {template.category}
+                        </span>
+                    )}
+                </div>
+
+                <p className={cn(
+                    "text-muted-foreground leading-relaxed flex-1 mt-1",
+                    isList ? "text-sm truncate" : "text-xs line-clamp-3"
+                )}>
+                    {template.description || "No description provided."}
+                </p>
+
+                {/* Footer: Metadata & Actions */}
+                <div className={cn(
+                    "flex items-center justify-between",
+                    !isList && "pt-3 border-t border-border/40 mt-auto",
+                    isList && "mt-1 w-full sm:w-auto"
+                )}>
+                    {/* Metadata Row */}
+                    <div className="flex items-center gap-4 text-muted-foreground/70">
+                        <div className="flex items-center gap-1 text-[11px] whitespace-nowrap">
+                            Updated {updatedDate}
+                        </div>
+                        {isList && template.category && (
+                            <span className="px-2 py-0.5 bg-primary/10 rounded-full text-[10px] font-bold uppercase tracking-wider text-primary border border-primary/20 hidden sm:inline-block truncate">
+                                {template.category}
+                            </span>
+                        )}
+                    </div>
+
+                    {/* Actions */}
+                    {(onEdit || onPreview || onDelete) && (
+                        <div className="flex items-center gap-1.5 ml-auto">
+                            {onPreview && <ActionButton onClick={onPreview} icon={Eye} title="Preview" />}
+                            {onEdit && <ActionButton onClick={onEdit} icon={Edit2} title="Edit" />}
+                            {onDelete && <ActionButton onClick={onDelete} icon={Trash2} title="Delete" variant="danger" disabled={deleting} />}
+                        </div>
+                    )}
+                </div>
+            </div>
         </div>
-      </CardHeader>
-      <CardContent className="space-y-3 text-sm text-foreground/90">
-        {template.description && <p className="text-muted-foreground">{template.description}</p>}
-        <p className="text-muted-foreground leading-relaxed">
-          {excerpt}
-          {excerpt.length === 140 && "…"}
-        </p>
-      </CardContent>
-      <CardFooter className="flex items-center justify-between gap-3 border-t pt-4">
-        <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" className="gap-2" onClick={onPreview}>
-            <Eye size={16} />
-            Preview
-          </Button>
-          <Button variant="outline" size="sm" className="gap-2" onClick={onEdit}>
-            <Pencil size={16} />
-            Edit
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="gap-2 text-rose-600"
-            onClick={onDelete}
-            disabled={deleting}
-          >
-            <Trash2 size={16} />
-            Delete
-          </Button>
-        </div>
-        <span className="text-xs text-muted-foreground">
-          Updated {new Date(template.updated_at).toLocaleDateString()}
-        </span>
-      </CardFooter>
-    </Card>
-  );
+    )
 }

--- a/web/src/components/templates/TemplateFormModal.tsx
+++ b/web/src/components/templates/TemplateFormModal.tsx
@@ -1,6 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { toast } from "sonner";
+import FormTooltip from "@/components/shared/FormTooltip";
 import type { Template } from "./types";
 
 interface FormState {
@@ -25,6 +27,38 @@ interface Props {
 export function TemplateFormModal({ showForm, editingTemplate, form, setForm, onClose, onSave, isSaving }: Props) {
   if (!showForm) return null;
 
+  const isEmail = form.path === "/templates/emails/";
+  
+  const hasRedirect = form.html.includes("${{redirect}}");
+  const hasPixel = form.html.includes("${{pixel}}");
+  
+  let validationError: string | null = null;
+  if (isEmail) {
+    if (!hasRedirect || !hasPixel) {
+      validationError = "Email templates must include both ${{redirect}} and ${{pixel}} variables.";
+    }
+  } else {
+    if (!hasRedirect) {
+      validationError = "Landing page templates must include the ${{redirect}} variable.";
+    }
+  }
+
+  const handleSave = () => {
+    if (!form.name.trim() || !form.html.trim()) {
+      toast.error("Please fill in all required fields.");
+      return;
+    }
+    if (isEmail && !form.subject.trim()) {
+      toast.error("Email templates must have a subject line.");
+      return;
+    }
+    if (validationError) {
+      toast.error(validationError);
+      return;
+    }
+    onSave();
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm p-4">
       <div className="w-full max-w-3xl rounded-2xl bg-background shadow-2xl overflow-hidden border">
@@ -41,16 +75,20 @@ export function TemplateFormModal({ showForm, editingTemplate, form, setForm, on
             Close
           </Button>
         </div>
-        <div className="p-6 space-y-4 h-500px overflow-y-auto">
+        <div className="p-6 space-y-4 max-h-[70vh] overflow-y-auto">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <Input
-              placeholder="Name"
-              value={form.name}
-              onChange={(e) => setForm({ ...form, name: e.target.value })}
-            />
-            <div className="space-y-1">
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">Name <span className="text-destructive">*</span></label>
+              <Input
+                placeholder="e.g., Q3 Password Expiry Notice"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">Type <span className="text-destructive">*</span></label>
               <select
-                className="h-10 w-full rounded-md border px-3 text-sm"
+                className="h-10 w-full rounded-md border border-input bg-transparent px-3 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                 value={form.path}
                 onChange={(e) => setForm({ ...form, path: e.target.value })}
               >
@@ -58,28 +96,55 @@ export function TemplateFormModal({ showForm, editingTemplate, form, setForm, on
                 <option value="/templates/pages/">Landing page</option>
               </select>
             </div>
-            <Input
-              placeholder="Subject"
-              value={form.subject}
-              onChange={(e) => setForm({ ...form, subject: e.target.value })}
-            />
-            <Input
-              placeholder="Category (optional)"
-              value={form.category}
-              onChange={(e) => setForm({ ...form, category: e.target.value })}
-            />
-            <Input
-              placeholder="Description (optional)"
-              value={form.description}
-              onChange={(e) => setForm({ ...form, description: e.target.value })}
+
+            {isEmail && (
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium">Subject <span className="text-destructive">*</span></label>
+                <Input
+                  placeholder="e.g., Action Required: Update Your password"
+                  value={form.subject}
+                  onChange={(e) => setForm({ ...form, subject: e.target.value })}
+                />
+              </div>
+            )}
+
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">Category</label>
+              <Input
+                placeholder="e.g., Credential Harvesting"
+                value={form.category}
+                onChange={(e) => setForm({ ...form, category: e.target.value })}
+              />
+            </div>
+            <div className="space-y-1.5 md:col-span-2">
+              <label className="text-sm font-medium">Description</label>
+              <Input
+                placeholder="e.g., Simulates a standard IT password expiration email."
+                value={form.description}
+                onChange={(e) => setForm({ ...form, description: e.target.value })}
+              />
+            </div>
+          </div>
+          
+          <div className="space-y-1.5 pt-2">
+            <div className="flex items-center gap-2">
+              <label className="text-sm font-medium">HTML Content <span className="text-destructive">*</span></label>
+              <FormTooltip 
+                side="right" 
+                content={
+                  isEmail 
+                    ? ["Email templates must contain ${{redirect}} (to redirect the user to the simulation page) and ${{pixel}} (to inject a tracking pixel into the email)."]
+                    : ["Landing page templates must contain ${{redirect}} (to redirect the user after the simulated interaction)."]
+                }
+              />
+            </div>
+            <Textarea
+              placeholder={isEmail ? "<html>... ${{redirect}} ... ${{pixel}} ...</html>" : "<html>... ${{redirect}} ...</html>"}
+              className="min-h-[200px] h-[200px] resize-y font-mono text-sm"
+              value={form.html}
+              onChange={(e) => setForm({ ...form, html: e.target.value })}
             />
           </div>
-          <Textarea
-            placeholder="HTML content"
-            className="h-500px overflow-y-auto"
-            value={form.html}
-            onChange={(e) => setForm({ ...form, html: e.target.value })}
-          />
         </div>
         <div className="flex items-center justify-end gap-3 px-6 py-4 border-t bg-surface-subtle">
           <Button variant="ghost" onClick={onClose}>
@@ -87,13 +152,8 @@ export function TemplateFormModal({ showForm, editingTemplate, form, setForm, on
           </Button>
           <Button
             className="gap-2"
-            onClick={onSave}
-            disabled={
-              isSaving ||
-              !form.name.trim() ||
-              !form.subject.trim() ||
-              !form.html.trim()
-            }
+            onClick={handleSave}
+            disabled={isSaving}
           >
             {isSaving ? "Saving..." : "Save template"}
           </Button>

--- a/web/src/components/templates/TemplatePreviewModal.tsx
+++ b/web/src/components/templates/TemplatePreviewModal.tsx
@@ -14,7 +14,6 @@ export function TemplatePreviewModal({ template, onClose }: Props) {
           <div>
             <p className="text-xs uppercase tracking-wide text-muted-foreground">HTML preview</p>
             <h3 className="text-lg font-semibold text-foreground">{template.name}</h3>
-            <p className="text-sm text-muted-foreground">{template.subject}</p>
           </div>
           <Button variant="ghost" onClick={onClose} className="text-muted-foreground">
             Close

--- a/web/src/components/templates/types.ts
+++ b/web/src/components/templates/types.ts
@@ -2,7 +2,7 @@ export interface Template {
   id: string;
   name: string;
   path: string;
-  subject: string;
+  subject?: string | null;
   category?: string | null;
   description?: string | null;
   html: string;

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-9 w-full min-w-0 border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
         "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
         "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
         className

--- a/web/src/config/navLinks.ts
+++ b/web/src/config/navLinks.ts
@@ -210,6 +210,12 @@ export const contentManagerLinks: NavLinkDef[] = [
         icon: FileText,
         group: "Phishing",
     },
+    {
+        href: "/content-manager/settings",
+        label: "Settings",
+        icon: Settings,
+        showOnWelcome: false,
+    },
 ];
 
 // ── Footer links (shared) ────────────────────────────────────────────────────

--- a/web/src/services/templateApi.ts
+++ b/web/src/services/templateApi.ts
@@ -1,0 +1,17 @@
+import { apiClient } from "@/lib/api-client";
+import type { Template } from "@/components/templates/types";
+
+export const templateApi = {
+  getTemplates: () => apiClient.get<Template[]>("/templates"),
+  
+  getTemplate: (id: string) => apiClient.get<Template>(`/templates/${id}`),
+  
+  createTemplate: (data: Omit<Template, "id" | "created_at" | "updated_at" | "org_id">) => 
+    apiClient.post<Template>("/templates", data),
+    
+  updateTemplate: (id: string, data: Partial<Template>) => 
+    apiClient.put<Template>(`/templates/${id}`, data),
+    
+  deleteTemplate: (id: string) => 
+    apiClient.delete(`/templates/${id}`) as Promise<void>,
+};


### PR DESCRIPTION
This PR add:

-> Now organizations can create templates of their own, which are not visible by the platform nor the other organizations.

-> Revamped some of the frontend to be more consistent with the rest of the app

-> Changed some services in the backend to be more efficient and atomic.

-> Fixed sidebar to permit all groups to be closed.

-> Now template creation enforces fields ${{redirect}} and ${{pixel}} to exist. Both frontend and backend do this verification.