### PR TITLE
SL 238 Fix access control

### DIFF
--- a/web/src/config/navLinks.ts
+++ b/web/src/config/navLinks.ts
@@ -57,6 +57,7 @@ export const adminLinks: NavLinkDef[] = [
         href: "/admin",
         label: "Dashboard",
         icon: LayoutDashboard,
+        roles: ["admin"],
         exact: true,
         showOnWelcome: false,
     },
@@ -65,18 +66,21 @@ export const adminLinks: NavLinkDef[] = [
         label: "Tenant Management",
         description: "Create and manage organizations, configure features and access controls.",
         icon: Building2,
+        roles: ["admin"],
     },
     {
         href: "/admin/logs",
         label: "System Logs",
         description: "Monitor real-time platform activity and system events.",
         icon: ScrollText,
+        roles: ["admin"],
     },
     {
         href: "/admin/settings",
         label: "Settings",
         description: "Configure theme.",
         icon: Settings,
+        roles: ["admin"],
     },
 ];
 
@@ -198,6 +202,7 @@ export const contentManagerLinks: NavLinkDef[] = [
         href: "/content-manager",
         label: "Dashboard",
         icon: LayoutDashboard,
+        roles: ["CONTENT_MANAGER"],
         exact: true,
         showOnWelcome: false,
     },
@@ -206,6 +211,7 @@ export const contentManagerLinks: NavLinkDef[] = [
         label: "Courses",
         description: "Create and manage training courses.",
         icon: BookOpen,
+        roles: ["CONTENT_MANAGER"],
         group: "LMS",
     },
     {
@@ -213,6 +219,7 @@ export const contentManagerLinks: NavLinkDef[] = [
         label: "Modules",
         description: "Organise content into reusable modules.",
         icon: Blocks,
+        roles: ["CONTENT_MANAGER"],
         group: "LMS",
     },
     {
@@ -220,6 +227,7 @@ export const contentManagerLinks: NavLinkDef[] = [
         label: "Content",
         description: "Upload and manage media and learning materials.",
         icon: FileStack,
+        roles: ["CONTENT_MANAGER"],
         group: "LMS",
     },
     {
@@ -227,12 +235,14 @@ export const contentManagerLinks: NavLinkDef[] = [
         label: "Templates",
         description: "Design and maintain reusable email and page templates.",
         icon: FileText,
+        roles: ["CONTENT_MANAGER"],
         group: "Phishing",
     },
     {
         href: "/content-manager/settings",
         label: "Settings",
         icon: Settings,
+        roles: ["CONTENT_MANAGER"],
         showOnWelcome: false,
     },
 ];

--- a/web/src/lib/route-access.ts
+++ b/web/src/lib/route-access.ts
@@ -1,0 +1,111 @@
+import {
+  adminLinks,
+  contentManagerLinks,
+  userLinks,
+  type NavLinkDef,
+} from "@/config/navLinks";
+
+type RoutePolicy = {
+  prefix: string;
+  roles?: string[];
+  feature?: string;
+};
+
+type RouteAccessInput = {
+  pathname: string;
+  userRoles: string[];
+  realmFeatures: Record<string, boolean>;
+  realmName?: string;
+};
+
+const ROUTE_POLICIES: RoutePolicy[] = buildRoutePolicies([
+  ...adminLinks,
+  ...contentManagerLinks,
+  ...userLinks,
+]);
+
+function buildRoutePolicies(links: NavLinkDef[]) {
+  const policyByPrefix = new Map<string, RoutePolicy>();
+
+  for (const link of links) {
+    if (!link.roles && !link.feature) {
+      continue;
+    }
+
+    policyByPrefix.set(link.href, {
+      prefix: link.href,
+      roles: link.roles,
+      feature: link.feature,
+    });
+  }
+
+  return [...policyByPrefix.values()].sort(
+    (left, right) => right.prefix.length - left.prefix.length,
+  );
+}
+
+function matchesPrefix(pathname: string, prefix: string) {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+function normalizeRoles(userRoles: string[]) {
+  return new Set(userRoles.map((role) => role.toLowerCase()));
+}
+
+function normalizeRequiredRole(requiredRole: string, realmName?: string) {
+  const resolvedRole =
+    requiredRole === "default-roles-$realmname" && realmName
+      ? `default-roles-${realmName}`
+      : requiredRole;
+  return resolvedRole.toLowerCase();
+}
+
+function hasRequiredRole(
+  userRoles: string[],
+  requiredRoles: string[],
+  realmName?: string,
+) {
+  const normalizedRoles = normalizeRoles(userRoles);
+  return requiredRoles.some((requiredRole) =>
+    normalizedRoles.has(normalizeRequiredRole(requiredRole, realmName)),
+  );
+}
+
+export function canAccessPath({
+  pathname,
+  userRoles,
+  realmFeatures,
+  realmName,
+}: RouteAccessInput) {
+  const matchingPolicy = ROUTE_POLICIES.find((policy) =>
+    matchesPrefix(pathname, policy.prefix),
+  );
+
+  if (!matchingPolicy) {
+    return true;
+  }
+
+  if (matchingPolicy.feature && !realmFeatures[matchingPolicy.feature]) {
+    return false;
+  }
+
+  if (matchingPolicy.roles) {
+    return hasRequiredRole(userRoles, matchingPolicy.roles, realmName);
+  }
+
+  return true;
+}
+
+export function getDefaultAuthorizedPath(userRoles: string[]) {
+  const normalizedRoles = normalizeRoles(userRoles);
+
+  if (normalizedRoles.has("admin")) {
+    return "/admin";
+  }
+
+  if (normalizedRoles.has("content_manager")) {
+    return "/content-manager";
+  }
+
+  return "/dashboard";
+}

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -1,10 +1,36 @@
 import { Navbar } from "@/components/navbar";
-import { createRootRoute, Outlet } from "@tanstack/react-router";
+import { AppLoader } from "@/components/AppLoader";
+import { getDefaultAuthorizedPath, canAccessPath } from "@/lib/route-access";
+import { createRootRoute, Navigate, Outlet, useRouterState } from "@tanstack/react-router";
 import { Sidebar } from "@/components/sidebar";
 import ComplianceFlow from "@/components/compliance";
 import { NotFound } from "@/components/NotFound";
+import { useKeycloak } from "@react-keycloak/web";
 
 const RootLayout = () => {
+  const { keycloak, initialized } = useKeycloak();
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+
+  if (!initialized) {
+    return <AppLoader visible label="Loading SecureLearning..." />;
+  }
+
+  const userRoles = keycloak.tokenParsed?.realm_access?.roles ?? [];
+  const realmFeatures =
+    (keycloak.tokenParsed as { features?: Record<string, boolean> } | undefined)
+      ?.features ?? {};
+  const fallbackPath = getDefaultAuthorizedPath(userRoles);
+  const allowed = canAccessPath({
+    pathname,
+    userRoles,
+    realmFeatures,
+    realmName: keycloak.realm,
+  });
+
+  if (!allowed && pathname !== fallbackPath) {
+    return <Navigate to={fallbackPath} replace />;
+  }
+
   return (
     <div className="h-screen bg-background text-foreground">
       <Navbar />


### PR DESCRIPTION
This pull request introduces role-based access control for navigation links and routes in the web application. The main changes include adding `roles` metadata to navigation link definitions and implementing a centralized route access utility that checks user roles and features before allowing access to specific paths. Additionally, the root route component now enforces these access rules, redirecting unauthorized users to an appropriate default page.

**Role-based navigation and route access:**

* Added a `roles` property to each relevant entry in `adminLinks` and `contentManagerLinks` within `web/src/config/navLinks.ts` to specify which user roles are allowed to access each link. [[1]](diffhunk://#diff-0526f5d3deec34e75c410f8e49d5af70734050bf627427943ccfe18dca238c12R60) [[2]](diffhunk://#diff-0526f5d3deec34e75c410f8e49d5af70734050bf627427943ccfe18dca238c12R69-R83) [[3]](diffhunk://#diff-0526f5d3deec34e75c410f8e49d5af70734050bf627427943ccfe18dca238c12R205) [[4]](diffhunk://#diff-0526f5d3deec34e75c410f8e49d5af70734050bf627427943ccfe18dca238c12R214-R245)
* Created a new utility module `web/src/lib/route-access.ts` that builds route access policies from navigation links, normalizes user roles, and provides functions to check if a user can access a given path (`canAccessPath`) and to determine a default authorized path for a user (`getDefaultAuthorizedPath`).

**Route access enforcement in root layout:**

* Updated `web/src/routes/__root.tsx` to use the new route access utility, extracting user roles and features from the Keycloak token, checking access for the current path, and redirecting unauthorized users to their default authorized page. Also added a loading indicator while authentication is initializing.