### PR TITLE
SL 281 modular report generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,3 +151,6 @@ Each tenant = Keycloak realm. `realm_name` scopes all data. `CurrentRealm` dep e
 - **`Pages/` is PascalCase**, feature dirs kebab-case. Intentional.
 - **`routeTree.gen.ts` auto-generated.** Never edit manually.
 - **SMTP worker blocking pika.** Single-threaded, auto-reconnect loop.
+- **Report module** at `api/src/services/reports/`. Pipeline: `ReportBuilder → ReportSpec → ReportService → collectors → HTML sections → ReportRenderer → PdfConverter (WeasyPrint)`. Public API: `report_service.generate(spec, session)` → PDF bytes; `report_service.render_html(spec, session)` → HTML string. No HTTP endpoint yet. System deps: `pango cairo fontconfig ttf-dejavu` (Dockerfile). Full detail in `CONTEXT.md`.
+- **Risk collector is stub.** `collectors/risk.py` returns zeros. K/S/E not integrated.
+- **Report `__init__.py` eager-imports** keycloak + Settings. Anything loading the module outside a live env must use importlib to bypass — see `CONTEXT.md` bootstrap section.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,6 +4,10 @@ FROM python:3.12-alpine AS base
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
+# WeasyPrint system dependencies for PDF report generation (Markdown → HTML → PDF).
+# pango + cairo replace the old pandoc + texmf-dist-latexextra stack (~1 GB saved).
+RUN apk add --no-cache pango cairo fontconfig ttf-dejavu
+
 # Copy dependency files
 COPY pyproject.toml uv.lock /app/
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "pypdf",
     "cryptography>=46.0.3",
     "prometheus-fastapi-instrumentator>=0.9.0",
+    "weasyprint>=68.1",
+    "markdown>=3.10.2",
 ]
 
 [dependency-groups]

--- a/api/scripts/run_report.py
+++ b/api/scripts/run_report.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Standalone dev tool — renders a full executive report using synthetic data.
+
+No database, no Keycloak, no RabbitMQ required.
+
+    uv run python scripts/run_report.py                        # HTML to stdout
+    uv run python scripts/run_report.py --out /tmp/report.html
+    uv run python scripts/run_report.py --pdf --out /tmp/report.pdf
+    uv run python scripts/run_report.py --realm acme --title "Q2 2025 Report"
+
+Design note
+-----------
+src/services/reports/__init__.py imports ReportService → collectors → campaign service
+→ keycloak → pydantic Settings (requires live env vars). This script bypasses that
+entirely using importlib to load only the rendering layer by absolute file path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Locate src tree
+# ---------------------------------------------------------------------------
+_HERE = Path(__file__).resolve().parent
+_API_ROOT = _HERE.parent
+_SRC = _API_ROOT / "src"
+_REPORTS = _SRC / "services" / "reports"
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+  if name in sys.modules:
+    return sys.modules[name]
+  spec = importlib.util.spec_from_file_location(name, path)
+  if spec is None or spec.loader is None:
+    raise ImportError(f"Cannot locate module at {path}")
+  mod = importlib.util.module_from_spec(spec)
+  sys.modules[name] = mod
+  spec.loader.exec_module(mod)  # type: ignore[union-attr]
+  return mod
+
+
+def _bootstrap() -> None:
+  if str(_API_ROOT) not in sys.path:
+    sys.path.insert(0, str(_API_ROOT))
+  p = "src.services.reports"
+  _load_module(f"{p}.spec",                            _REPORTS / "spec.py")
+  _load_module(f"{p}.context",                         _REPORTS / "context.py")
+  _load_module(f"{p}.sections._html",                  _REPORTS / "sections" / "_html.py")
+  _load_module(f"{p}.sections.base",                   _REPORTS / "sections" / "base.py")
+  _load_module(f"{p}.sections.risk",                   _REPORTS / "sections" / "risk.py")
+  _load_module(f"{p}.sections.global_stats",           _REPORTS / "sections" / "global_stats.py")
+  _load_module(f"{p}.sections.campaign_stats",         _REPORTS / "sections" / "campaign_stats.py")
+  _load_module(f"{p}.sections.compliance",             _REPORTS / "sections" / "compliance.py")
+  _load_module(f"{p}.sections.executive_summary",      _REPORTS / "sections" / "executive_summary.py")
+  _load_module(f"{p}.sections.risk_outlook",           _REPORTS / "sections" / "risk_outlook.py")
+  _load_module(f"{p}.sections.operations_outlook",     _REPORTS / "sections" / "operations_outlook.py")
+  _load_module(f"{p}.sections",                        _REPORTS / "sections" / "__init__.py")
+  _load_module(f"{p}.renderer",                        _REPORTS / "renderer.py")
+  _load_module(f"{p}.builder",                         _REPORTS / "builder.py")
+
+
+_bootstrap()
+
+from src.services.reports.builder import ReportBuilder          # noqa: E402
+from src.services.reports.context import (                      # noqa: E402
+  ComplianceMetrics,
+  DataContext,
+  RiskMetrics,
+)
+from src.services.reports.renderer import ReportRenderer        # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Synthetic fixtures
+# ---------------------------------------------------------------------------
+
+def _global_stats() -> Any:
+  return SimpleNamespace(
+    total_campaigns=5,
+    scheduled_campaigns=1,
+    running_campaigns=1,
+    completed_campaigns=3,
+    canceled_campaigns=0,
+    total_emails_scheduled=1_100,
+    total_emails_sent=1_000,
+    total_emails_opened=450,
+    total_emails_clicked=200,
+    total_emails_phished=80,
+    total_emails_failed=10,
+    delivery_rate=99.0,
+    open_rate=45.0,
+    click_rate=20.0,
+    phish_rate=8.0,
+    avg_time_to_open_seconds=135.0,
+    avg_time_to_click_seconds=310.0,
+    unique_users_targeted=300,
+    users_who_opened=180,
+    users_who_clicked=60,
+    users_who_phished=24,
+    repeat_offenders=["user_001", "user_002"],  # anonymised IDs, not emails
+  )
+
+
+def _campaign_detail(campaign_id: int) -> Any:
+  class _Status(str):
+    def __new__(cls) -> "_Status":
+      obj = str.__new__(cls, "completed")
+      obj.value = "completed"
+      return obj
+
+  profiles: dict[int, dict] = {
+    1: dict(
+      name="Finance Department — Q1 Phishing Simulation",
+      description="Credential-harvest simulation targeting finance staff.",
+      begin_date=datetime(2025, 1, 6, 9, 0),
+      end_date=datetime(2025, 1, 31, 18, 0),
+      user_group_ids=["group-finance"],
+      phishing_kit_names=["DocuSign Invoice Request"],
+      sending_profile_names=["SMTP-Primary"],
+      total_recipients=80,
+      total_sent=78,
+      total_opened=52,
+      total_clicked=28,
+      total_phished=14,
+      total_failed=2,
+      delivery_rate=97.5,
+      open_rate=66.7,
+      click_rate=35.9,
+      phish_rate=17.9,
+      avg_time_to_open_seconds=95.0,
+      avg_time_to_click_seconds=220.0,
+    ),
+    2: dict(
+      name="IT Team — Q1 Post-Training Verification",
+      description="Follow-up simulation after mandatory awareness training.",
+      begin_date=datetime(2025, 2, 3, 9, 0),
+      end_date=datetime(2025, 2, 28, 18, 0),
+      user_group_ids=["group-it"],
+      phishing_kit_names=["Microsoft 365 Login Page"],
+      sending_profile_names=["SMTP-Primary"],
+      total_recipients=45,
+      total_sent=45,
+      total_opened=18,
+      total_clicked=5,
+      total_phished=2,
+      total_failed=0,
+      delivery_rate=100.0,
+      open_rate=40.0,
+      click_rate=11.1,
+      phish_rate=4.4,
+      avg_time_to_open_seconds=180.0,
+      avg_time_to_click_seconds=420.0,
+    ),
+  }
+  defaults = dict(
+    name=f"General Simulation (ID {campaign_id})",
+    description="Quarterly phishing awareness simulation.",
+    begin_date=datetime(2025, 3, 1, 9, 0),
+    end_date=datetime(2025, 3, 31, 18, 0),
+    user_group_ids=["group-all-staff"],
+    phishing_kit_names=["Generic Login Page"],
+    sending_profile_names=["SMTP-Primary"],
+    total_recipients=120,
+    total_sent=118,
+    total_opened=60,
+    total_clicked=22,
+    total_phished=9,
+    total_failed=2,
+    delivery_rate=98.3,
+    open_rate=50.8,
+    click_rate=18.6,
+    phish_rate=7.6,
+    avg_time_to_open_seconds=120.0,
+    avg_time_to_click_seconds=270.0,
+  )
+  data = profiles.get(campaign_id, defaults)
+  return SimpleNamespace(
+    id=campaign_id,
+    realm_name="acme",
+    status=_Status(),
+    sending_interval_seconds=3_600,
+    progress_percentage=100.0,
+    time_elapsed_percentage=100.0,
+    first_open_at=data["begin_date"],
+    last_open_at=data["end_date"],
+    first_click_at=data["begin_date"],
+    last_click_at=data["end_date"],
+    **data,
+  )
+
+
+def _risk_metrics() -> RiskMetrics:
+  return RiskMetrics(
+    knowledge_score=0.0,
+    sentiment_score=0.0,
+    involvement_score=0.0,
+    risk_level="N/A",
+    notes="Risk scoring pending K/S/E data integration.",
+  )
+
+
+def _compliance_metrics() -> ComplianceMetrics:
+  return ComplianceMetrics(
+    total_users=300,
+    compliant_users=240,
+    compliance_rate=80.0,
+    avg_score=78.5,
+    avg_attempts_to_pass=1.6,
+  )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _parse_args() -> argparse.Namespace:
+  parser = argparse.ArgumentParser(description="Render a SecureLearning executive report with synthetic data.")
+  parser.add_argument("--realm", default="acme-demo", help="Realm/tenant name.")
+  parser.add_argument("--title", default="Security Awareness Report", help="Report title.")
+  parser.add_argument("--pdf", action="store_true", help="Output PDF instead of HTML.")
+  parser.add_argument("--out", type=Path, default=None, help="Write output to PATH. Default: stdout.")
+  return parser.parse_args()
+
+
+def _build(args: argparse.Namespace) -> str:
+  campaign_ids = [1, 2]
+  spec = (
+    ReportBuilder(title=args.title, realm_name=args.realm)
+    .add_executive_summary()
+    .add_risk_outlook()
+    .add_operations_outlook(campaign_ids=campaign_ids)
+    .build()
+  )
+  ctx = DataContext(
+    realm_name=spec.realm_name,
+    generated_at=spec.generated_at,
+    global_stats=_global_stats(),
+    campaign_details=[_campaign_detail(cid) for cid in campaign_ids],
+    risk_metrics=_risk_metrics(),
+    compliance_metrics=_compliance_metrics(),
+  )
+  return ReportRenderer().render(spec, ctx)
+
+
+def _to_pdf(html: str) -> bytes:
+  try:
+    from weasyprint import HTML
+  except ImportError as exc:
+    raise RuntimeError("weasyprint not installed — run: uv add weasyprint") from exc
+  return HTML(string=html).write_pdf()
+
+
+def main() -> int:
+  args = _parse_args()
+  want_pdf = args.pdf or (args.out and args.out.suffix.lower() == ".pdf")
+
+  html = _build(args)
+
+  if want_pdf:
+    print("⏳  Converting HTML → PDF via WeasyPrint …", file=sys.stderr)
+    try:
+      output = _to_pdf(html)
+    except RuntimeError as exc:
+      print(f"❌  {exc}", file=sys.stderr)
+      return 1
+    if args.out:
+      args.out.parent.mkdir(parents=True, exist_ok=True)
+      args.out.write_bytes(output)
+      print(f"✅  PDF written → {args.out}", file=sys.stderr)
+    else:
+      sys.stdout.buffer.write(output)
+  else:
+    if args.out:
+      args.out.parent.mkdir(parents=True, exist_ok=True)
+      args.out.write_text(html, encoding="utf-8")
+      print(f"✅  HTML written → {args.out}", file=sys.stderr)
+    else:
+      print(html)
+
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/api/src/services/reports/__init__.py
+++ b/api/src/services/reports/__init__.py
@@ -1,0 +1,36 @@
+"""Reports service package.
+
+Public API::
+
+    from src.services.reports import report_service, ReportBuilder
+
+    spec = (
+        ReportBuilder(title="Q1 Report", realm_name="acme")
+        .add_risk_report()
+        .add_global_stats()
+        .add_campaign_stats(campaign_ids=[1, 2, 3])
+        .add_compliance()
+        .build()
+    )
+    pdf_bytes = report_service.generate(spec, session)
+"""
+
+from src.services.reports.builder import ReportBuilder
+from src.services.reports.context import ComplianceMetrics, DataContext, RiskMetrics
+from src.services.reports.service import ReportService
+from src.services.reports.spec import ReportSpec, SectionConfig, SectionKind
+
+# Module-level singleton — follows the established pattern in this codebase
+report_service = ReportService()
+
+__all__ = [
+  "report_service",
+  "ReportService",
+  "ReportBuilder",
+  "ReportSpec",
+  "SectionConfig",
+  "SectionKind",
+  "DataContext",
+  "RiskMetrics",
+  "ComplianceMetrics",
+]

--- a/api/src/services/reports/builder.py
+++ b/api/src/services/reports/builder.py
@@ -1,0 +1,84 @@
+"""Fluent builder for constructing a ReportSpec."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from src.services.reports.spec import ReportSpec, SectionConfig, SectionKind
+
+
+class ReportBuilder:
+  """Fluent API for composing a ReportSpec.
+
+  Usage::
+
+      spec = (
+          ReportBuilder(title="Q1 Security Report", realm_name="acme")
+          .add_risk_report()
+          .add_global_stats()
+          .add_campaign_stats(campaign_ids=[1, 2, 3])
+          .add_compliance()
+          .build()
+      )
+  """
+
+  def __init__(self, title: str, realm_name: str) -> None:
+    self._title = title
+    self._realm_name = realm_name
+    self._sections: list[SectionConfig] = []
+
+  # ------------------------------------------------------------------
+  # Section registration helpers
+  # ------------------------------------------------------------------
+
+  def add_risk_report(self) -> ReportBuilder:
+    """Append a risk overview section (K/S/E components + overall score)."""
+    self._sections.append(SectionConfig(kind=SectionKind.RISK))
+    return self
+
+  def add_global_stats(self) -> ReportBuilder:
+    """Append a global campaign statistics section."""
+    self._sections.append(SectionConfig(kind=SectionKind.GLOBAL_STATS))
+    return self
+
+  def add_campaign_stats(self, campaign_ids: list[int]) -> ReportBuilder:
+    """Append a per-campaign statistics section for the given campaign IDs."""
+    self._sections.append(
+      SectionConfig(kind=SectionKind.CAMPAIGN_STATS, campaign_ids=campaign_ids)
+    )
+    return self
+
+  def add_compliance(self) -> ReportBuilder:
+    """Append a compliance quiz summary section (avg score + avg attempts)."""
+    self._sections.append(SectionConfig(kind=SectionKind.COMPLIANCE))
+    return self
+
+  def add_executive_summary(self) -> ReportBuilder:
+    """Append an executive summary section (posture badge, key findings, actions)."""
+    self._sections.append(SectionConfig(kind=SectionKind.EXECUTIVE_SUMMARY))
+    return self
+
+  def add_risk_outlook(self) -> ReportBuilder:
+    """Append a board-level risk outlook section (plain language, human framing)."""
+    self._sections.append(SectionConfig(kind=SectionKind.RISK_OUTLOOK))
+    return self
+
+  def add_operations_outlook(self, campaign_ids: list[int] | None = None) -> ReportBuilder:
+    """Append an operations outlook section (campaign detail + compliance for IT teams)."""
+    self._sections.append(
+      SectionConfig(kind=SectionKind.OPERATIONS_OUTLOOK, campaign_ids=campaign_ids or [])
+    )
+    return self
+
+  # ------------------------------------------------------------------
+  # Build
+  # ------------------------------------------------------------------
+
+  def build(self) -> ReportSpec:
+    """Produce an immutable ReportSpec from the current configuration."""
+    return ReportSpec(
+      title=self._title,
+      realm_name=self._realm_name,
+      generated_at=datetime.now(),
+      sections=tuple(self._sections),
+    )

--- a/api/src/services/reports/collectors/__init__.py
+++ b/api/src/services/reports/collectors/__init__.py
@@ -1,0 +1,13 @@
+"""Collectors package."""
+
+from src.services.reports.collectors.campaign_stats import collect_campaign_stats
+from src.services.reports.collectors.compliance import collect_compliance_metrics
+from src.services.reports.collectors.global_stats import collect_global_stats
+from src.services.reports.collectors.risk import collect_risk_metrics
+
+__all__ = [
+  "collect_global_stats",
+  "collect_campaign_stats",
+  "collect_compliance_metrics",
+  "collect_risk_metrics",
+]

--- a/api/src/services/reports/collectors/campaign_stats.py
+++ b/api/src/services/reports/collectors/campaign_stats.py
@@ -1,0 +1,26 @@
+"""Campaign stats collector — fetches detail info for a list of campaign IDs."""
+
+from __future__ import annotations
+
+from sqlmodel import Session, select
+
+from src.models import Campaign, CampaignDetailInfo
+from src.services.campaign.stats_handler import get_stats_handler
+
+
+def collect_campaign_stats(
+  campaign_ids: list[int], session: Session
+) -> list[CampaignDetailInfo]:
+  """Fetch CampaignDetailInfo for each of the given campaign IDs.
+
+  Campaigns that are not found in the database are silently skipped.
+  """
+  if not campaign_ids:
+    return []
+
+  handler = get_stats_handler()
+  campaigns = session.exec(
+    select(Campaign).where(Campaign.id.in_(campaign_ids))  # type: ignore[attr-defined]
+  ).all()
+
+  return [handler._to_detail_info(c) for c in campaigns]

--- a/api/src/services/reports/collectors/compliance.py
+++ b/api/src/services/reports/collectors/compliance.py
@@ -1,0 +1,56 @@
+"""Compliance collector — aggregates quiz acceptance records for the realm."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlmodel import Session, select
+
+from src.models import ComplianceAcceptance
+from src.services.reports.context import ComplianceMetrics
+
+
+def collect_compliance_metrics(realm_name: str, session: Session) -> ComplianceMetrics:
+  """Compute compliance statistics from ComplianceAcceptance records.
+
+  Derives:
+  - compliance_rate: users with at least one accepted record / unique users seen
+  - avg_score: mean score across all acceptance records
+  - avg_attempts_to_pass: mean number of attempts a user needed before their
+    first accepted record (approximated from record count per user)
+  """
+  records = session.exec(
+    select(ComplianceAcceptance).where(ComplianceAcceptance.tenant == realm_name)
+  ).all()
+
+  if not records:
+    return ComplianceMetrics()
+
+  # Group records by user
+  by_user: dict[str, list[ComplianceAcceptance]] = defaultdict(list)
+  for rec in records:
+    by_user[rec.user_identifier].append(rec)
+
+  total_users = len(by_user)
+  # A user is "compliant" if they have at least one passing record (score > 0)
+  compliant_users = sum(
+    1 for user_records in by_user.values() if any(r.score > 0 for r in user_records)
+  )
+  compliance_rate = round(compliant_users / total_users * 100, 2) if total_users else 0.0
+
+  all_scores = [r.score for r in records]
+  avg_score = round(sum(all_scores) / len(all_scores), 2) if all_scores else 0.0
+
+  # Approximate attempts per user as the number of records they have
+  attempts_per_user = [len(user_records) for user_records in by_user.values()]
+  avg_attempts = (
+    round(sum(attempts_per_user) / len(attempts_per_user), 2) if attempts_per_user else 0.0
+  )
+
+  return ComplianceMetrics(
+    total_users=total_users,
+    compliant_users=compliant_users,
+    compliance_rate=compliance_rate,
+    avg_score=avg_score,
+    avg_attempts_to_pass=avg_attempts,
+  )

--- a/api/src/services/reports/collectors/global_stats.py
+++ b/api/src/services/reports/collectors/global_stats.py
@@ -1,0 +1,14 @@
+"""Global stats collector — wraps StatsHandler to populate DataContext."""
+
+from __future__ import annotations
+
+from sqlmodel import Session
+
+from src.models import CampaignGlobalStats
+from src.services.campaign.stats_handler import get_stats_handler
+
+
+def collect_global_stats(realm_name: str, session: Session) -> CampaignGlobalStats:
+  """Fetch global campaign statistics for the given realm."""
+  handler = get_stats_handler()
+  return handler.get_global_stats(realm_name, session)

--- a/api/src/services/reports/collectors/risk.py
+++ b/api/src/services/reports/collectors/risk.py
@@ -1,0 +1,21 @@
+"""Risk collector — returns placeholder RiskMetrics (K/S/E pending integration)."""
+
+from __future__ import annotations
+
+from src.services.reports.context import RiskMetrics
+
+
+def collect_risk_metrics(realm_name: str) -> RiskMetrics:  # noqa: ARG001
+  """Return a RiskMetrics object for the given realm.
+
+  Currently returns zeroed placeholder values.  When K / S / E data sources
+  are available, this function will query them and populate the real scores.
+  The overall_score is computed automatically in RiskMetrics.__post_init__.
+  """
+  return RiskMetrics(
+    knowledge_score=0.0,
+    sentiment_score=0.0,
+    involvement_score=0.0,
+    risk_level="N/A",
+    notes="Risk calculation pending K/S/E data integration.",
+  )

--- a/api/src/services/reports/context.py
+++ b/api/src/services/reports/context.py
@@ -1,0 +1,62 @@
+"""DataContext: pre-fetched data bag passed to all section renderers.
+
+All database / service calls happen once, populating a DataContext.  The
+renderers then receive this context and perform no additional I/O.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from src.models import CampaignDetailInfo, CampaignGlobalStats
+
+
+@dataclass
+class RiskMetrics:
+  """Risk scoring derived from K/S/E components.
+
+  All three sub-scores are currently placeholders pending full K/S/E data
+  integration.  The overall_score is computed as the simple mean of the
+  three components so the structure is already wired up correctly.
+  """
+
+  # Sub-components (0.0–100.0 scale; 0.0 while data is not yet available)
+  knowledge_score: float = 0.0    # K — measures user security knowledge level
+  sentiment_score: float = 0.0    # S — measures user security attitude / sentiment
+  involvement_score: float = 0.0  # E — measures user engagement / involvement
+
+  # Derived overall risk score (mean of K, S, E); 0.0 while components are mocked
+  overall_score: float = 0.0
+
+  risk_level: str = "N/A"
+  notes: str = "Risk calculation pending K/S/E data integration."
+
+  def __post_init__(self) -> None:
+    # Recompute overall whenever the dataclass is created
+    components = [self.knowledge_score, self.sentiment_score, self.involvement_score]
+    if any(c > 0 for c in components):
+      self.overall_score = round(sum(components) / len(components), 2)
+
+
+@dataclass
+class ComplianceMetrics:
+  """Aggregated compliance quiz statistics for a realm."""
+
+  total_users: int = 0
+  compliant_users: int = 0
+  compliance_rate: float = 0.0      # compliant / total * 100
+  avg_score: float = 0.0            # average quiz score across all acceptances
+  avg_attempts_to_pass: float = 0.0 # average number of tries before passing
+
+
+@dataclass
+class DataContext:
+  """All data collected for a report, passed read-only to section renderers."""
+
+  realm_name: str
+  generated_at: datetime
+  global_stats: CampaignGlobalStats | None = None
+  campaign_details: list[CampaignDetailInfo] = field(default_factory=list)
+  risk_metrics: RiskMetrics = field(default_factory=RiskMetrics)
+  compliance_metrics: ComplianceMetrics | None = None

--- a/api/src/services/reports/pdf_converter.py
+++ b/api/src/services/reports/pdf_converter.py
@@ -1,0 +1,44 @@
+"""PdfConverter — converts an HTML string to PDF bytes via WeasyPrint.
+
+Pipeline: HTML → PDF (no LaTeX, no Pandoc required).
+
+WeasyPrint renders HTML/CSS to PDF using the system's Pango/Cairo libs.
+Install:
+
+    uv add weasyprint
+
+System deps (present on any GTK-based Linux desktop / Alpine with pango+cairo):
+  - libpango, libcairo
+"""
+
+from __future__ import annotations
+
+
+class PdfConverter:
+  """Converts a self-contained HTML document to a PDF binary using WeasyPrint.
+
+  The HTML is expected to already contain all styling (embedded ``<style>``
+  tags) — WeasyPrint does not load external resources by default.
+  """
+
+  def convert(self, html: str) -> bytes:
+    """Convert an HTML document string to PDF bytes.
+
+    Args:
+        html: A complete HTML document string (including ``<html>``,
+              ``<head>``, and embedded ``<style>``).
+
+    Returns:
+        Raw PDF bytes.
+
+    Raises:
+        RuntimeError: If weasyprint is not installed.
+    """
+    try:
+      from weasyprint import HTML  # local import keeps module importable without weasyprint
+    except ImportError as exc:
+      raise RuntimeError(
+        "weasyprint is not installed. Run: uv add weasyprint"
+      ) from exc
+
+    return HTML(string=html).write_pdf()

--- a/api/src/services/reports/renderer.py
+++ b/api/src/services/reports/renderer.py
@@ -1,0 +1,186 @@
+"""ReportRenderer — assembles a full HTML document from a ReportSpec and DataContext."""
+
+from __future__ import annotations
+
+from src.services.reports.context import DataContext
+from src.services.reports.sections import (
+  CampaignStatsSection,
+  ComplianceSection,
+  ExecutiveSummarySection,
+  GlobalStatsSection,
+  OperationsOutlookSection,
+  ReportSection,
+  RiskOutlookSection,
+  RiskReportSection,
+)
+from src.services.reports.spec import ReportSpec, SectionKind
+
+# Registry mapping SectionKind → concrete section class
+_SECTION_REGISTRY: dict[SectionKind, type[ReportSection]] = {
+  SectionKind.RISK: RiskReportSection,
+  SectionKind.GLOBAL_STATS: GlobalStatsSection,
+  SectionKind.CAMPAIGN_STATS: CampaignStatsSection,
+  SectionKind.COMPLIANCE: ComplianceSection,
+  SectionKind.EXECUTIVE_SUMMARY: ExecutiveSummarySection,
+  SectionKind.RISK_OUTLOOK: RiskOutlookSection,
+  SectionKind.OPERATIONS_OUTLOOK: OperationsOutlookSection,
+}
+
+# ---------------------------------------------------------------------------
+# Stylesheet — embedded directly in the generated HTML so the document is
+# fully self-contained (no external CSS files needed for WeasyPrint).
+# ---------------------------------------------------------------------------
+_CSS = """
+:root {
+  --blue:       #0f3460;
+  --navy:       #16213e;
+  --text:       #1e293b;
+  --muted:      #64748b;
+  --border:     #e2e8f0;
+  --surface:    #f8fafc;
+  --callout-bg: #eef2ff;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: 'DejaVu Sans', Arial, sans-serif;
+  font-size: 11pt;
+  line-height: 1.6;
+  color: var(--text);
+  max-width: 21cm;
+  margin: 0 auto;
+}
+
+@page {
+  size: A4;
+  margin: 2.2cm 2.5cm;
+  @bottom-center {
+    content: counter(page) " of " counter(pages);
+    font-size: 8pt;
+    color: var(--muted);
+  }
+}
+
+/* ── Header ── */
+header            { margin-bottom: 2em; text-align: center; }
+header h1         { font-size: 24pt; font-weight: 700; color: var(--blue);
+                    border-bottom: 3px solid var(--blue); padding-bottom: 0.5em;
+                    margin-bottom: 0.6em; display: inline-block; }
+.meta             { font-size: 10pt; color: var(--muted); text-align: center; }
+.meta strong      { color: var(--text); font-weight: 600; }
+
+/* ── Sections ── */
+.report-section        { margin-bottom: 2.5em; padding: 0; }
+.report-section > h2   { font-size: 16pt; font-weight: 700; color: var(--navy);
+                         border-bottom: 2px solid var(--blue);
+                         padding-bottom: 0.4em; margin-bottom: 1em; margin-top: 0; }
+
+.sub              { margin: 0.8em 0 1.2em; padding: 0; }
+.sub h3           { font-size: 12pt; font-weight: 700; color: var(--navy); margin-bottom: 0.6em; }
+.sub h4           { font-size: 10.5pt; font-weight: 600; color: var(--muted); margin-bottom: 0.4em; }
+
+.campaign-entry          { border: 1px solid var(--border); border-radius: 4pt;
+                           padding: 1.2em; margin-bottom: 1.5em; background: #fafbfc; }
+.campaign-entry > h3     { font-size: 12pt; font-weight: 700; color: var(--blue); margin-bottom: 1em; }
+
+/* ── Tables ── */
+table             { border-collapse: collapse; width: 100%; margin: 0.6em 0 1.2em; font-size: 10pt; }
+thead tr          { background: var(--blue); color: #fff; }
+th, td            { padding: 7pt 10pt; text-align: left; border: 0.5px solid #ddd; }
+tbody tr:nth-child(even)  { background: var(--surface); }
+tbody td          { border-bottom: 0.5px solid var(--border); }
+tbody tr:last-child td    { border-bottom: 0.5px solid var(--border); }
+
+/* key-value table */
+table.kv          { margin: 0.6em 0 1em; }
+table.kv th       { background: var(--surface); font-weight: 600; width: 45%;
+                    text-align: left; padding: 7pt 10pt; }
+table.kv td       { padding: 7pt 10pt; }
+table.kv tr:last-child th,
+table.kv tr:last-child td { border-bottom: none; }
+
+.num              { text-align: right; }
+
+/* ── Callout ── */
+.callout          { border-left: 5px solid var(--blue); background: var(--callout-bg);
+                    padding: 0.8em 1.2em; border-radius: 0 4pt 4pt 0; margin: 0.8em 0; }
+.callout p        { margin: 0.25em 0; font-size: 10pt; line-height: 1.5; }
+
+/* ── Misc ── */
+ul                { padding-left: 1.5em; margin: 0.4em 0; }
+li                { margin: 0.2em 0; font-size: 10pt; }
+code              { font-family: 'DejaVu Sans Mono', Courier, monospace; font-size: 9pt;
+                    background: var(--surface); padding: 1pt 4pt; border-radius: 2pt; }
+hr                { border: none; border-top: 1px solid var(--border); margin: 1.5em 0; }
+.section-sep      { border: none; border-top: 2px solid #c7d2e0; margin: 2.5em 0; }
+.empty            { color: var(--muted); font-style: italic; font-size: 10pt; }
+
+/* ── Badges ── */
+.badge            { display: inline-block; padding: 2pt 7pt; border-radius: 3pt;
+                    font-size: 9pt; font-weight: 600; }
+.badge-green      { background: #dcfce7; color: #166534; }
+.badge-amber      { background: #fef9c3; color: #854d0e; }
+.badge-red        { background: #fee2e2; color: #991b1b; }
+.badge-blue       { background: #dbeafe; color: #1e40af; }
+
+/* ── Financial figures ── */
+.fig              { font-size: 12pt; font-weight: 700; color: var(--blue); }
+
+/* ── Executive card ── */
+.exec-card        { border: 1px solid var(--border); border-radius: 4pt;
+                    padding: 1em 1.2em; margin-bottom: 1em; background: var(--surface); }
+
+/* ── Footer ── */
+footer            { margin-top: 3em; padding-top: 1em; font-size: 9pt;
+                    color: var(--muted); text-align: center;
+                    border-top: 1px solid var(--border); }
+"""
+
+
+class ReportRenderer:
+  """Orchestrates HTML generation from a ReportSpec and DataContext.
+
+  Sections are rendered in the order they appear in the spec.  The renderer
+  itself is stateless — all state lives in the spec and context.
+  """
+
+  def render(self, spec: ReportSpec, ctx: DataContext) -> str:
+    """Produce a complete, self-contained HTML document string."""
+    section_html = []
+    for section_config in spec.sections:
+      section_cls = _SECTION_REGISTRY.get(section_config.kind)
+      if section_cls is None:
+        section_html.append(
+          f'<section class="report-section">'
+          f"<p><em>Unknown section: {section_config.kind}</em></p>"
+          f"</section>"
+        )
+        continue
+      section_html.append(section_cls().render(section_config, ctx))
+
+    body = '<div class="section-sep"></div>'.join(section_html)
+    generated = spec.generated_at.strftime("%Y-%m-%d %H:%M UTC")
+
+    return (
+      "<!DOCTYPE html>"
+      '<html lang="en">'
+      "<head>"
+      '<meta charset="UTF-8">'
+      f"<title>{spec.title}</title>"
+      f"<style>{_CSS}</style>"
+      "</head>"
+      "<body>"
+      "<header>"
+      f"<h1>{spec.title}</h1>"
+      f'<p class="meta"><strong>Realm:</strong> {spec.realm_name} &nbsp;|&nbsp; '
+      f"<strong>Generated:</strong> {generated}</p>"
+      "</header>"
+      "<hr>"
+      f"{body}"
+      "<hr>"
+      f"<footer>Report generated on {spec.generated_at.strftime('%Y-%m-%d')} "
+      "by SecureLearning.</footer>"
+      "</body>"
+      "</html>"
+    )

--- a/api/src/services/reports/sections/__init__.py
+++ b/api/src/services/reports/sections/__init__.py
@@ -1,0 +1,22 @@
+"""Sections package — re-exports all concrete section classes."""
+
+from src.services.reports.sections.base import ReportSection
+from src.services.reports.sections.campaign_stats import CampaignStatsSection
+from src.services.reports.sections.compliance import ComplianceSection
+from src.services.reports.sections.executive_summary import ExecutiveSummarySection
+from src.services.reports.sections.global_stats import GlobalStatsSection
+from src.services.reports.sections.operations_outlook import OperationsOutlookSection
+from src.services.reports.sections.risk import RiskReportSection
+from src.services.reports.sections.risk_outlook import RiskOutlookSection
+
+__all__ = [
+  "ReportSection",
+  "ReportSection",
+  "RiskReportSection",
+  "GlobalStatsSection",
+  "CampaignStatsSection",
+  "ComplianceSection",
+  "ExecutiveSummarySection",
+  "RiskOutlookSection",
+  "OperationsOutlookSection",
+]

--- a/api/src/services/reports/sections/_html.py
+++ b/api/src/services/reports/sections/_html.py
@@ -1,0 +1,125 @@
+"""Lightweight HTML fragment helpers shared by all report section renderers.
+
+All functions return plain strings of HTML — no DOM, no dependencies.
+Sections compose these building blocks to produce their HTML fragments.
+"""
+
+from __future__ import annotations
+
+
+def table(
+  headers: list[str],
+  rows: list[list[str]],
+  num_cols: frozenset[int] = frozenset(),
+) -> str:
+  """Render a ``<table>`` with a styled header row.
+
+  Args:
+      headers: Column header labels.
+      rows: Each inner list is one row of cell values (already-safe strings).
+      num_cols: Column indices that should be right-aligned (numeric data).
+  """
+  ths = "".join(f"<th>{h}</th>" for h in headers)
+  trs = []
+  for row in rows:
+    tds = "".join(
+      f'<td class="num">{v}</td>' if i in num_cols else f"<td>{v}</td>"
+      for i, v in enumerate(row)
+    )
+    trs.append(f"<tr>{tds}</tr>")
+  return (
+    f"<table><thead><tr>{ths}</tr></thead>"
+    f"<tbody>{''.join(trs)}</tbody></table>"
+  )
+
+
+def kv_table(rows: list[tuple[str, str]]) -> str:
+  """Two-column key → value table (no header row)."""
+  trs = "".join(f"<tr><th>{k}</th><td>{v}</td></tr>" for k, v in rows)
+  return f"<table class='kv'><tbody>{trs}</tbody></table>"
+
+
+def subsection(title: str, *content: str, level: int = 3) -> str:
+  """Wrap content in a titled ``<div class="sub">`` block."""
+  body = "\n".join(content)
+  return f'<div class="sub"><h{level}>{title}</h{level}>{body}</div>'
+
+
+def callout(*lines: str) -> str:
+  """Render a highlighted callout box."""
+  inner = "".join(f"<p>{line}</p>" for line in lines)
+  return f'<div class="callout">{inner}</div>'
+
+
+def empty_state(msg: str) -> str:
+  """Muted italic placeholder for missing data."""
+  return f'<p class="empty">{msg}</p>'
+
+
+def badge(text: str, level: str) -> str:
+  """Inline status badge. level: 'green' | 'amber' | 'red' | 'blue'."""
+  return f'<span class="badge badge-{level}">{text}</span>'
+
+
+def stat_row(
+  cells: list[tuple[str, str, str | None]],
+  *,
+  danger: frozenset[int] = frozenset(),
+  accent: frozenset[int] = frozenset(),
+) -> str:
+  """Horizontal stat table matching the campaign-detail design.
+
+  cells: [(label, value, sublabel|None), ...]
+  danger: column indices rendered red  (bad metric — fell for simulation, outstanding)
+  accent: column indices rendered dark blue (key summary figure)
+  """
+  _TH = "padding:5pt 8pt; text-align:center; font-weight:600;"
+  _TD = "padding:6pt 8pt; text-align:center; border:1px solid #e2e8f0;"
+
+  ths, tds = [], []
+  for i, (label, value, sub) in enumerate(cells):
+    if i in danger:
+      ths.append(f'<th style="{_TH} background:#7f1d1d;">{label}</th>')
+      td_s = f"{_TD} background:#fff5f5;"
+      val_s = "font-size:11pt; font-weight:700; color:#991b1b;"
+      sub_s = "color:#991b1b; font-size:8pt;"
+    elif i in accent:
+      ths.append(f'<th style="{_TH} background:#16213e;">{label}</th>')
+      td_s = f"{_TD} background:#eef2ff;"
+      val_s = "font-size:11pt; font-weight:700; color:#0f3460;"
+      sub_s = "color:#0f3460; font-size:8pt;"
+    else:
+      ths.append(f'<th style="{_TH}">{label}</th>')
+      td_s, val_s, sub_s = _TD, "font-size:11pt; font-weight:700;", "color:#64748b; font-size:8pt;"
+
+    sub_html = f'<br><span style="{sub_s}">{sub}</span>' if sub else ""
+    tds.append(f'<td style="{td_s}"><span style="{val_s}">{value}</span>{sub_html}</td>')
+
+  return (
+    '<table style="width:100%; font-size:9pt; border-collapse:collapse; margin:0.6em 0;">'
+    '<thead><tr style="background:#0f3460; color:#fff;">'
+    + "".join(ths)
+    + '</tr></thead><tbody><tr style="background:#f8fafc;">'
+    + "".join(tds)
+    + "</tr></tbody></table>"
+  )
+
+
+def meta_line(*parts: str) -> str:
+  """Muted meta line with dot separators between parts."""
+  sep = '&nbsp;&nbsp;·&nbsp;&nbsp;'
+  joined = sep.join(f"<strong>{p.split(':', 1)[0]}:</strong> {p.split(':', 1)[1]}" if ":" in p else p for p in parts)
+  return f'<p style="font-size:9.5pt; color:#64748b; margin:0.2em 0 0.8em 0;">{joined}</p>'
+
+
+def fmt_seconds(seconds: float | None) -> str:
+  """Convert seconds to human-readable 'X min Y sec'."""
+  if seconds is None:
+    return "N/A"
+  total = int(seconds)
+  mins, secs = divmod(total, 60)
+  if mins and secs:
+    return f"{mins} min {secs} sec"
+  if mins:
+    return f"{mins} min"
+  return f"{secs} sec"

--- a/api/src/services/reports/sections/base.py
+++ b/api/src/services/reports/sections/base.py
@@ -1,0 +1,31 @@
+"""Abstract base class for all report sections."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from src.services.reports.context import DataContext
+from src.services.reports.spec import SectionConfig
+
+
+class ReportSection(ABC):
+  """A single renderable block of a report.
+
+  Each concrete subclass renders one section type and returns an **HTML
+  fragment** (a ``<section>`` element string).  Sections must be stateless —
+  all I/O happens in collectors before rendering starts.
+  """
+
+  @abstractmethod
+  def render(self, config: SectionConfig, ctx: DataContext) -> str:
+    """Render this section to an HTML fragment.
+
+    Args:
+        config: The SectionConfig for this specific section instance.
+        ctx: The pre-populated DataContext shared by all sections.
+
+    Returns:
+        An HTML string — typically a ``<section class="report-section">``
+        element containing headings, tables, and other markup.
+    """
+    ...

--- a/api/src/services/reports/sections/campaign_stats.py
+++ b/api/src/services/reports/sections/campaign_stats.py
@@ -1,0 +1,95 @@
+"""Per-simulation detailed breakdown section."""
+
+from __future__ import annotations
+
+from src.services.reports.context import DataContext
+from src.services.reports.sections._html import (
+  empty_state,
+  fmt_seconds,
+  kv_table,
+  subsection,
+  table,
+)
+from src.services.reports.sections.base import ReportSection
+from src.services.reports.spec import SectionConfig
+
+
+class CampaignStatsSection(ReportSection):
+  """Renders one HTML sub-block per requested simulation campaign."""
+
+  def render(self, config: SectionConfig, ctx: DataContext) -> str:
+    if not ctx.campaign_details:
+      return (
+        '<section class="report-section">'
+        "<h2>Simulation Campaigns — Detailed Breakdown</h2>"
+        + empty_state("No simulation data available.")
+        + "</section>"
+      )
+
+    target_ids = set(config.campaign_ids) if config.campaign_ids else None
+    campaigns = (
+      [c for c in ctx.campaign_details if c.id in target_ids] if target_ids else ctx.campaign_details
+    )
+
+    if not campaigns:
+      return (
+        '<section class="report-section">'
+        "<h2>Simulation Campaigns — Detailed Breakdown</h2>"
+        + empty_state("No matching simulations found for the requested selection.")
+        + "</section>"
+      )
+
+    entries = "\n".join(self._render_campaign(c) for c in campaigns)
+    return f'<section class="report-section"><h2>Simulation Campaigns — Detailed Breakdown</h2>{entries}</section>'
+
+  # ------------------------------------------------------------------
+
+  @staticmethod
+  def _render_campaign(c: object) -> str:
+    begin = c.begin_date.strftime("%Y-%m-%d %H:%M")
+    end = c.end_date.strftime("%Y-%m-%d %H:%M")
+
+    meta = subsection(
+      "Details",
+      kv_table([
+        ("Status", str(c.status).capitalize()),
+        ("Start date", begin),
+        ("End date", end),
+        ("Email delivery spacing", fmt_seconds(c.sending_interval_seconds)),
+        ("Phishing kits used", ", ".join(c.phishing_kit_names) or "—"),
+        ("Sending profiles", ", ".join(c.sending_profile_names) or "—"),
+      ]),
+      level=4,
+    )
+
+    funnel_rows = [
+      ["Recipients", str(c.total_recipients), "—"],
+      ["Delivered", str(c.total_sent), f"{c.delivery_rate:.1f}%"],
+      ["Opened", str(c.total_opened), f"{c.open_rate:.1f}%"],
+      ["Clicked link", str(c.total_clicked), f"{c.click_rate:.1f}%"],
+      ["Fell for simulation", str(c.total_phished), f"{c.phish_rate:.1f}%"],
+      ["Failed to deliver", str(c.total_failed), "—"],
+    ]
+    funnel = subsection(
+      "Results Breakdown",
+      table(["Stage", "Count", "Rate"], funnel_rows, num_cols=frozenset({1, 2})),
+      level=4,
+    )
+
+    timing = subsection(
+      "Timing",
+      kv_table([
+        ("Avg. time to open", fmt_seconds(c.avg_time_to_open_seconds)),
+        ("Avg. time to click", fmt_seconds(c.avg_time_to_click_seconds)),
+        ("Completion", f"{c.progress_percentage:.1f}%"),
+        ("Time elapsed", f"{c.time_elapsed_percentage:.1f}%"),
+      ]),
+      level=4,
+    )
+
+    return (
+      f'<div class="campaign-entry">'
+      f"<h3>{c.name}</h3>"
+      f"{meta}{funnel}{timing}"
+      f"</div>"
+    )

--- a/api/src/services/reports/sections/compliance.py
+++ b/api/src/services/reports/sections/compliance.py
@@ -1,0 +1,74 @@
+"""Security training completion section."""
+
+from __future__ import annotations
+
+from src.services.reports.context import ComplianceMetrics, DataContext
+from src.services.reports.sections._html import (
+  callout,
+  empty_state,
+  subsection,
+  table,
+)
+from src.services.reports.sections.base import ReportSection
+from src.services.reports.spec import SectionConfig
+
+
+class ComplianceSection(ReportSection):
+  """Renders security training completion statistics for the realm.
+
+  Highlights:
+  - Overall completion rate (users who passed vs total)
+  - Training gap (employees still outstanding)
+  - Average quiz score across all acceptances
+  - Average number of attempts before passing
+  """
+
+  def render(self, config: SectionConfig, ctx: DataContext) -> str:
+    if ctx.compliance_metrics is None:
+      return (
+        '<section class="report-section">'
+        "<h2>Security Training Completion</h2>"
+        + empty_state("No training data available.")
+        + "</section>"
+      )
+    m = ctx.compliance_metrics
+    return (
+      '<section class="report-section">'
+      "<h2>Security Training Completion</h2>"
+      + self._overview(m)
+      + self._quiz_performance(m)
+      + "</section>"
+    )
+
+  # ------------------------------------------------------------------
+
+  @staticmethod
+  def _overview(m: ComplianceMetrics) -> str:
+    non_compliant = m.total_users - m.compliant_users
+    rows = [
+      ["Total employees", str(m.total_users)],
+      ["Completed training", str(m.compliant_users)],
+      ["Yet to complete", str(non_compliant)],
+      ["Completion rate", f"{m.compliance_rate:.1f}%"],
+    ]
+    gap_callout = (
+      callout(
+        f"<strong>{non_compliant} employee{'s' if non_compliant != 1 else ''}</strong> still need to complete mandatory security training.",
+        "Follow up with managers to ensure outstanding employees complete training promptly.",
+      )
+      if non_compliant > 0
+      else callout("All employees have completed mandatory security training. Well done.")
+    )
+    return subsection(
+      "Completion Overview",
+      table(["Metric", "Value"], rows, num_cols=frozenset({1})),
+      gap_callout,
+    )
+
+  @staticmethod
+  def _quiz_performance(m: ComplianceMetrics) -> str:
+    rows = [
+      ["Average quiz score", f"{m.avg_score:.1f}%"],
+      ["Avg. quiz attempts before passing", f"{m.avg_attempts_to_pass:.1f}"],
+    ]
+    return subsection("Quiz Performance", table(["Metric", "Value"], rows, num_cols=frozenset({1})))

--- a/api/src/services/reports/sections/executive_summary.py
+++ b/api/src/services/reports/sections/executive_summary.py
@@ -1,0 +1,138 @@
+"""Executive summary section — single-page at-a-glance overview for leadership."""
+
+from __future__ import annotations
+
+from src.services.reports.context import DataContext
+from src.services.reports.sections._html import badge, callout, meta_line, stat_row, subsection
+from src.services.reports.sections.base import ReportSection
+from src.services.reports.spec import SectionConfig
+
+
+def _posture(phish_rate: float, compliance_rate: float) -> tuple[str, str]:
+  """Return (label, badge_level) based on phish + compliance thresholds."""
+  if phish_rate < 5 and compliance_rate >= 85:
+    return "Strong", "green"
+  if phish_rate < 10 and compliance_rate >= 70:
+    return "Improving", "amber"
+  return "Needs Attention", "red"
+
+
+class ExecutiveSummarySection(ReportSection):
+  """Single-page executive overview — posture, key findings, and recommended actions."""
+
+  def render(self, config: SectionConfig, ctx: DataContext) -> str:
+    return (
+      '<section class="report-section">'
+      "<h2>Executive Summary</h2>"
+      + self._snapshot(ctx)
+      + self._findings(ctx)
+      + self._recommendations(ctx)
+      + "</section>"
+    )
+
+  # ------------------------------------------------------------------
+
+  @staticmethod
+  def _snapshot(ctx: DataContext) -> str:
+    s = ctx.global_stats
+    m = ctx.compliance_metrics
+
+    phish_rate = s.phish_rate if s else 0.0
+    compliance_rate = m.compliance_rate if m else 0.0
+    total_targeted = s.unique_users_targeted if s else 0
+    users_phished = s.users_who_phished if s else 0
+    compliant = m.compliant_users if m else 0
+    total_users = m.total_users if m else 0
+    posture_label, posture_level = _posture(phish_rate, compliance_rate)
+
+    period = ctx.generated_at.strftime("%B %Y")
+    cards = stat_row(
+      [
+        ("Employees Targeted", str(total_targeted), None),
+        ("Fell for Simulation", f"{phish_rate:.1f}%", f"{users_phished} employees"),
+        ("Training Completion", f"{compliance_rate:.1f}%", f"{compliant} of {total_users} completed"),
+        ("Overall Posture", badge(posture_label, posture_level), None),
+      ],
+      danger=frozenset({1}),
+      accent=frozenset({2, 3}),
+    )
+    return subsection("At a Glance", meta_line(f"Period:{period}", f"Organisation:{ctx.realm_name}") + cards)
+
+  @staticmethod
+  def _findings(ctx: DataContext) -> str:
+    s = ctx.global_stats
+    m = ctx.compliance_metrics
+    items: list[str] = []
+
+    if s:
+      targeted = s.unique_users_targeted or 1
+      clicked = s.users_who_clicked
+      ratio = round(targeted / clicked) if clicked else 0
+      if clicked and ratio > 1:
+        benchmark = 12
+        comparison = (
+          "above the industry benchmark of 1 in 12"
+          if ratio < benchmark
+          else "in line with or better than the industry benchmark of 1 in 12"
+        )
+        items.append(f"1 in {ratio} employees clicked a link in a simulated phishing email — {comparison}.")
+      elif not clicked:
+        items.append("No employees clicked a link in any simulated phishing email this period.")
+
+      repeat_count = len(s.repeat_offenders)
+      if repeat_count > 0:
+        items.append(
+          f"{repeat_count} employee{'s' if repeat_count != 1 else ''} clicked on simulated phishing links more than once, indicating a need for targeted follow-up."
+        )
+
+    if m:
+      non_compliant = m.total_users - m.compliant_users
+      if non_compliant > 0:
+        items.append(
+          f"{m.compliant_users} of {m.total_users} employees ({m.compliance_rate:.0f}%) have completed mandatory security training — "
+          f"{non_compliant} still outstanding."
+        )
+      else:
+        items.append(f"All {m.total_users} employees have completed mandatory security training.")
+
+    if not items:
+      items.append("Insufficient data to generate findings for this period.")
+
+    bullets = "".join(f"<li>{item}</li>" for item in items)
+    return subsection("Key Findings", f"<ul>{bullets}</ul>")
+
+  @staticmethod
+  def _recommendations(ctx: DataContext) -> str:
+    s = ctx.global_stats
+    m = ctx.compliance_metrics
+    items: list[str] = []
+
+    phish_rate = s.phish_rate if s else 0.0
+    compliance_rate = m.compliance_rate if m else 100.0
+    repeat_count = len(s.repeat_offenders) if s else 0
+
+    if phish_rate > 10:
+      items.append(
+        "<strong>Priority — Reduce phishing exposure:</strong> Roll out a targeted refresher campaign focused on email recognition. "
+        "Consider simulating more advanced scenarios for high-risk departments."
+      )
+    if repeat_count > 0:
+      items.append(
+        f"<strong>Targeted coaching:</strong> The {repeat_count} employee{'s' if repeat_count != 1 else ''} flagged as repeat clickers "
+        "would benefit from one-on-one security coaching or an accelerated training module."
+      )
+    if compliance_rate < 70:
+      non_compliant = (m.total_users - m.compliant_users) if m else 0
+      items.append(
+        f"<strong>Close the training gap:</strong> {non_compliant} employees have not completed mandatory training. "
+        "Escalate to line managers and set a firm completion deadline."
+      )
+
+    if not items:
+      items.append(
+        "<strong>Maintain momentum:</strong> Security posture is strong. Continue running regular simulations and "
+        "refresher training to keep awareness levels high."
+      )
+
+    content = "".join(callout(item) for item in items)
+    return subsection("Recommended Actions", content)

--- a/api/src/services/reports/sections/global_stats.py
+++ b/api/src/services/reports/sections/global_stats.py
@@ -1,0 +1,100 @@
+"""Phishing simulation summary section."""
+
+from __future__ import annotations
+
+from src.services.reports.context import DataContext
+from src.services.reports.sections._html import (
+  callout,
+  empty_state,
+  fmt_seconds,
+  subsection,
+  table,
+)
+from src.services.reports.sections.base import ReportSection
+from src.services.reports.spec import SectionConfig
+
+
+class GlobalStatsSection(ReportSection):
+  """Renders a global overview of all phishing simulations in the realm."""
+
+  def render(self, config: SectionConfig, ctx: DataContext) -> str:
+    if ctx.global_stats is None:
+      return (
+        '<section class="report-section">'
+        "<h2>Phishing Simulation Summary</h2>"
+        + empty_state("No data available.")
+        + "</section>"
+      )
+    s = ctx.global_stats
+    return (
+      '<section class="report-section">'
+      "<h2>Phishing Simulation Summary</h2>"
+      + self._campaign_overview(s)
+      + self._email_funnel(s)
+      + self._engagement_rates(s)
+      + self._user_vulnerability(s)
+      + "</section>"
+    )
+
+  # ------------------------------------------------------------------
+
+  @staticmethod
+  def _campaign_overview(s: object) -> str:
+    rows = [
+      ["Total simulations", str(s.total_campaigns)],
+      ["Scheduled", str(s.scheduled_campaigns)],
+      ["Running", str(s.running_campaigns)],
+      ["Completed", str(s.completed_campaigns)],
+      ["Canceled", str(s.canceled_campaigns)],
+    ]
+    return subsection("Simulation Overview", table(["Metric", "Count"], rows, num_cols=frozenset({1})))
+
+  @staticmethod
+  def _email_funnel(s: object) -> str:
+    rows = [
+      ["Scheduled", str(s.total_emails_scheduled)],
+      ["Delivered", str(s.total_emails_sent)],
+      ["Opened", str(s.total_emails_opened)],
+      ["Clicked link", str(s.total_emails_clicked)],
+      ["Fell for simulation", str(s.total_emails_phished)],
+      ["Failed to deliver", str(s.total_emails_failed)],
+    ]
+    return subsection("Simulation Delivery Summary", table(["Stage", "Count"], rows, num_cols=frozenset({1})))
+
+  @staticmethod
+  def _engagement_rates(s: object) -> str:
+    avg_open = fmt_seconds(s.avg_time_to_open_seconds)
+    avg_click = fmt_seconds(s.avg_time_to_click_seconds)
+    rows = [
+      ["Delivery rate", f"{s.delivery_rate:.1f}%"],
+      ["Open rate", f"{s.open_rate:.1f}%"],
+      ["Click-through rate", f"{s.click_rate:.1f}%"],
+      ["Simulation success rate", f"{s.phish_rate:.1f}%"],
+      ["Avg. time to open", avg_open],
+      ["Avg. time to click", avg_click],
+    ]
+    return subsection("Engagement Rates", table(["Metric", "Value"], rows, num_cols=frozenset({1})))
+
+  @staticmethod
+  def _user_vulnerability(s: object) -> str:
+    repeat_count = len(s.repeat_offenders)
+    targeted = s.unique_users_targeted or 1
+    clicked = s.users_who_clicked
+    ratio_num = round(targeted / clicked) if clicked else 0
+    ratio_text = (
+      f"1 in {ratio_num} targeted employees clicked a link"
+      if clicked and ratio_num > 1
+      else ("All targeted employees avoided the link" if not clicked else "Every targeted employee clicked a link")
+    )
+    rows = [
+      ["Employees targeted", str(s.unique_users_targeted)],
+      ["Opened the email", str(s.users_who_opened)],
+      ["Clicked a link", str(s.users_who_clicked)],
+      ["Fell for simulation", str(s.users_who_phished)],
+      ["Repeat clickers", str(repeat_count)],
+    ]
+    return subsection(
+      "Employee Exposure",
+      table(["Metric", "Count"], rows, num_cols=frozenset({1})),
+      callout(ratio_text),
+    )

--- a/api/src/services/reports/sections/operations_outlook.py
+++ b/api/src/services/reports/sections/operations_outlook.py
@@ -1,0 +1,154 @@
+"""Operations Outlook section — detail-level view for IT and security teams."""
+
+from __future__ import annotations
+
+from src.services.reports.context import ComplianceMetrics, DataContext
+from src.services.reports.sections._html import (
+  callout,
+  empty_state,
+  fmt_seconds,
+  meta_line,
+  stat_row,
+  subsection,
+)
+from src.services.reports.sections.base import ReportSection
+from src.services.reports.spec import SectionConfig
+
+
+class OperationsOutlookSection(ReportSection):
+  """Combines campaign, compliance, and global stats detail for the security operations team."""
+
+  def render(self, config: SectionConfig, ctx: DataContext) -> str:
+    return (
+      '<section class="report-section">'
+      "<h2>Operations Outlook</h2>"
+      + self._global_summary(ctx)
+      + self._campaign_detail(config, ctx)
+      + self._compliance_detail(ctx)
+      + "</section>"
+    )
+
+  # ------------------------------------------------------------------
+
+  @staticmethod
+  def _global_summary(ctx: DataContext) -> str:
+    s = ctx.global_stats
+    if s is None:
+      return subsection("Simulation Summary", empty_state("No simulation data available."))
+
+    cards = stat_row(
+      [
+        ("Scheduled", str(s.total_emails_scheduled), None),
+        ("Delivered", str(s.total_emails_sent), f"{s.delivery_rate:.1f}% delivery rate"),
+        ("Opened", str(s.total_emails_opened), f"{s.open_rate:.1f}% of sent"),
+        ("Clicked Link", str(s.total_emails_clicked), f"{s.click_rate:.1f}% of sent"),
+        ("Fell for Simulation", str(s.total_emails_phished), f"{s.phish_rate:.1f}% of sent"),
+      ],
+      danger=frozenset({4}),
+    )
+
+    targeted_for_ratio = s.unique_users_targeted or 1
+    clicked = s.users_who_clicked
+    ratio = round(targeted_for_ratio / clicked) if clicked else 0
+    ratio_text = f"1 in {ratio} targeted employees clicked a link" if clicked and ratio > 1 else (
+      "No employees clicked a link" if not clicked else "All targeted employees clicked a link"
+    )
+
+    return subsection("Simulation Summary", cards, callout(ratio_text))
+
+  @staticmethod
+  def _campaign_detail(config: SectionConfig, ctx: DataContext) -> str:
+    if not ctx.campaign_details:
+      return subsection("Campaign Detail", empty_state("No campaign data available."))
+
+    target_ids = set(config.campaign_ids) if config.campaign_ids else None
+    campaigns = (
+      [c for c in ctx.campaign_details if c.id in target_ids] if target_ids else ctx.campaign_details
+    )
+
+    if not campaigns:
+      return subsection("Campaign Detail", empty_state("No matching campaigns found."))
+
+    entries = []
+    for c in campaigns:
+      begin = c.begin_date.strftime("%Y-%m-%d")
+      end = c.end_date.strftime("%Y-%m-%d")
+
+      summary_rows = [
+        ["Status", str(c.status).capitalize(), "Start", begin, "End", end],
+        [f"{c.total_recipients} recipients", f"{c.total_sent} sent ({c.delivery_rate:.0f}%)",
+         f"{c.total_opened} opened ({c.open_rate:.0f}%)", f"{c.total_clicked} clicked ({c.click_rate:.0f}%)",
+         f"{c.total_phished} fell ({c.phish_rate:.0f}%)", f"{c.total_failed} failed"],
+      ]
+      kit_names = ", ".join(c.phishing_kit_names) or "—"
+      meta = (
+        f'<p style="font-size:9.5pt; color:#64748b; margin:0.2em 0 0.8em 0;">'
+        f'<strong>Status:</strong> {str(c.status).capitalize()}'
+        f'&nbsp;&nbsp;·&nbsp;&nbsp;'
+        f'<strong>Period:</strong> {begin} — {end}'
+        f'&nbsp;&nbsp;·&nbsp;&nbsp;'
+        f'<strong>Kit:</strong> {kit_names}'
+        f'</p>'
+      )
+      funnel = (
+        '<table style="width:100%; font-size:9pt; border-collapse:collapse; margin:0;">'
+        '<thead>'
+        '<tr style="background:#0f3460; color:#fff;">'
+        '<th style="padding:5pt 8pt; text-align:center; font-weight:600;">Targeted</th>'
+        '<th style="padding:5pt 8pt; text-align:center; font-weight:600;">Sent</th>'
+        '<th style="padding:5pt 8pt; text-align:center; font-weight:600;">Opened</th>'
+        '<th style="padding:5pt 8pt; text-align:center; font-weight:600;">Clicked Link</th>'
+        '<th style="padding:5pt 8pt; text-align:center; font-weight:600; background:#7f1d1d;">Fell for Simulation</th>'
+        '</tr>'
+        '</thead>'
+        '<tbody>'
+        '<tr style="background:#f8fafc;">'
+        f'<td style="padding:6pt 8pt; text-align:center; border:1px solid #e2e8f0; font-size:11pt; font-weight:700;">{c.total_recipients}</td>'
+        f'<td style="padding:6pt 8pt; text-align:center; border:1px solid #e2e8f0;"><span style="font-size:11pt; font-weight:700;">{c.total_sent}</span><br><span style="color:#64748b; font-size:8pt;">{c.delivery_rate:.0f}% delivered</span></td>'
+        f'<td style="padding:6pt 8pt; text-align:center; border:1px solid #e2e8f0;"><span style="font-size:11pt; font-weight:700;">{c.total_opened}</span><br><span style="color:#64748b; font-size:8pt;">{c.open_rate:.0f}% of sent</span></td>'
+        f'<td style="padding:6pt 8pt; text-align:center; border:1px solid #e2e8f0;"><span style="font-size:11pt; font-weight:700;">{c.total_clicked}</span><br><span style="color:#64748b; font-size:8pt;">{c.click_rate:.0f}% of sent</span></td>'
+        f'<td style="padding:6pt 8pt; text-align:center; border:1px solid #e2e8f0; background:#fff5f5;"><span style="font-size:11pt; font-weight:700; color:#991b1b;">{c.total_phished}</span><br><span style="color:#991b1b; font-size:8pt;">{c.phish_rate:.0f}% of sent</span></td>'
+        '</tr>'
+        '</tbody>'
+        '</table>'
+      )
+      timing = meta_line(
+        f"Avg. open:{fmt_seconds(c.avg_time_to_open_seconds)}",
+        f"Avg. click:{fmt_seconds(c.avg_time_to_click_seconds)}",
+      )
+      entries.append(
+        f'<div class="campaign-entry" style="padding:0.9em 1em; margin-bottom:1em;">'
+        f'<h3 style="margin:0 0 0.3em 0; font-size:11pt;">{c.name}</h3>'
+        f'{meta}'
+        f'{funnel}'
+        f'{timing}'
+        f'</div>'
+      )
+
+    return subsection("Campaign Detail", *entries)
+
+  @staticmethod
+  def _compliance_detail(ctx: DataContext) -> str:
+    m: ComplianceMetrics | None = ctx.compliance_metrics
+    if m is None:
+      return subsection("Training Completion", empty_state("No training data available."))
+
+    non_compliant = m.total_users - m.compliant_users
+    cards = stat_row(
+      [
+        ("Total Employees", str(m.total_users), None),
+        ("Completed Training", str(m.compliant_users), f"{m.compliance_rate:.1f}% completion rate"),
+        ("Yet to Complete", str(non_compliant), "outstanding"),
+        ("Avg Quiz Score", f"{m.avg_score:.1f}%", f"{m.avg_attempts_to_pass:.1f} avg attempts"),
+      ],
+      accent=frozenset({1}),
+      danger=frozenset({2}) if non_compliant > 0 else frozenset(),
+    )
+    gap = (
+      callout(
+        f"<strong>{non_compliant} employee{'s' if non_compliant != 1 else ''}</strong> still need to complete mandatory security training."
+      )
+      if non_compliant > 0
+      else callout("All employees have completed mandatory training.")
+    )
+    return subsection("Training Completion", cards, gap)

--- a/api/src/services/reports/sections/risk.py
+++ b/api/src/services/reports/sections/risk.py
@@ -1,0 +1,86 @@
+"""Security Awareness Score section — renders K/S/E components and overall score."""
+
+from __future__ import annotations
+
+from src.services.reports.context import DataContext, RiskMetrics
+from src.services.reports.sections._html import (
+  callout,
+  empty_state,
+  subsection,
+  table,
+)
+from src.services.reports.sections.base import ReportSection
+from src.services.reports.spec import SectionConfig
+
+
+class RiskReportSection(ReportSection):
+  """Renders the security awareness score section.
+
+  Displays Knowledge (K), Sentiment (S), and Engagement (E) sub-scores,
+  derives an overall score, and surfaces repeat clickers and the
+  most exposed simulations.
+  """
+
+  def render(self, config: SectionConfig, ctx: DataContext) -> str:
+    return (
+      '<section class="report-section">'
+      "<h2>Security Awareness Score</h2>"
+      + self._scores_block(ctx.risk_metrics)
+      + self._offenders_block(ctx)
+      + self._vulnerable_campaigns_block(ctx)
+      + "</section>"
+    )
+
+  # ------------------------------------------------------------------
+
+  @staticmethod
+  def _scores_block(m: RiskMetrics) -> str:
+    if not any([m.knowledge_score, m.sentiment_score, m.involvement_score]):
+      return subsection(
+        "Awareness Scores",
+        callout("Awareness scoring is pending data collection. Scores will appear once Knowledge, Sentiment, and Engagement assessments are completed."),
+      )
+    rows = [
+      ["Knowledge Score", f"{m.knowledge_score:.1f}", "Measures how well employees understand security best practices"],
+      ["Sentiment Score", f"{m.sentiment_score:.1f}", "Reflects employee attitudes toward security policies"],
+      ["Engagement Score", f"{m.involvement_score:.1f}", "Tracks active participation in security activities"],
+      [
+        "<strong>Overall Score</strong>",
+        f"<strong>{m.overall_score:.1f}</strong>",
+        "Combined average of the three scores above",
+      ],
+    ]
+    return subsection(
+      "Awareness Scores",
+      table(["Component", "Score", "What it measures"], rows, num_cols=frozenset({1})),
+      callout(
+        f"<strong>Overall Risk Level:</strong> {m.risk_level}",
+        f"<em>{m.notes}</em>",
+      ),
+    )
+
+  @staticmethod
+  def _offenders_block(ctx: DataContext) -> str:
+    if ctx.global_stats is None:
+      return subsection("Repeat Clickers", empty_state("No simulation data available."))
+    count = len(ctx.global_stats.repeat_offenders)
+    if count == 0:
+      return subsection("Repeat Clickers", empty_state("No repeat clickers identified in this period."))
+    return subsection(
+      "Repeat Clickers",
+      callout(
+        f"<strong>{count} employee{'s' if count != 1 else ''}</strong> clicked on simulated phishing links more than once.",
+        "Individual coaching or targeted training is recommended for these employees.",
+      ),
+    )
+
+  @staticmethod
+  def _vulnerable_campaigns_block(ctx: DataContext) -> str:
+    if not ctx.campaign_details:
+      return subsection("Simulations with Highest Exposure", empty_state("No simulation data available."))
+    top = sorted(ctx.campaign_details, key=lambda c: c.phish_rate, reverse=True)[:5]
+    rows = [[c.name, f"{c.phish_rate:.1f}%", f"{c.click_rate:.1f}%"] for c in top]
+    return subsection(
+      "Simulations with Highest Exposure (Top 5)",
+      table(["Simulation Name", "Fell for Simulation", "Clicked Link"], rows, num_cols=frozenset({1, 2})),
+    )

--- a/api/src/services/reports/sections/risk_outlook.py
+++ b/api/src/services/reports/sections/risk_outlook.py
@@ -1,0 +1,225 @@
+"""Risk Outlook section — in-depth risk analysis for board and security leadership."""
+
+from __future__ import annotations
+
+from src.services.reports.context import DataContext, RiskMetrics
+from src.services.reports.sections._html import (
+  badge,
+  callout,
+  empty_state,
+  fmt_seconds,
+  stat_row,
+  subsection,
+  table,
+)
+from src.services.reports.sections.base import ReportSection
+from src.services.reports.spec import SectionConfig
+
+_INDUSTRY_CLICK_BENCHMARK = 12  # 1-in-N benchmark (Proofpoint State of the Phish 2024)
+
+
+class RiskOutlookSection(ReportSection):
+  """Deep risk analysis — phishing exposure, speed of compromise, K/S/E awareness, risk signals."""
+
+  def render(self, config: SectionConfig, ctx: DataContext) -> str:
+    return (
+      '<section class="report-section">'
+      "<h2>Risk Outlook</h2>"
+      + self._exposure_block(ctx)
+      + self._speed_block(ctx)
+      + self._campaign_risk_breakdown(ctx)
+      + self._scores_block(ctx.risk_metrics)
+      + self._repeat_clickers_block(ctx)
+      + self._risk_signals_block(ctx)
+      + "</section>"
+    )
+
+  # ------------------------------------------------------------------
+
+  @staticmethod
+  def _exposure_block(ctx: DataContext) -> str:
+    s = ctx.global_stats
+    if s is None:
+      return subsection("Phishing Exposure", empty_state("No simulation data available for this period."))
+
+    actual_targeted = s.unique_users_targeted
+    targeted_for_ratio = actual_targeted or 1
+    clicked = s.users_who_clicked
+    phished = s.users_who_phished
+    ratio = round(targeted_for_ratio / clicked) if clicked else 0
+
+    click_sub = f"{clicked / targeted_for_ratio * 100:.1f}% of targeted" if actual_targeted else None
+    cards = stat_row(
+      [
+        ("Employees Targeted", str(actual_targeted), None),
+        ("Clicked Link", str(clicked), click_sub),
+        ("Fell for Simulation", str(phished), f"{s.phish_rate:.1f}% of sent"),
+        ("Avg. Time to Click", fmt_seconds(s.avg_time_to_click_seconds), "from delivery"),
+      ],
+      danger=frozenset({2}),
+    )
+
+    if not clicked:
+      narrative = "No employees clicked a link in any simulated phishing email this period. Excellent result."
+    elif ratio >= _INDUSTRY_CLICK_BENCHMARK:
+      narrative = (
+        f"1 in {ratio} employees clicked a link in a simulated phishing email — "
+        f"in line with or better than the industry benchmark of 1 in {_INDUSTRY_CLICK_BENCHMARK}."
+      )
+    else:
+      narrative = (
+        f"1 in {ratio} employees clicked a link in a simulated phishing email. "
+        f"The industry benchmark is 1 in {_INDUSTRY_CLICK_BENCHMARK} — your organisation is above average risk."
+      )
+
+    lines = [narrative]
+    if phished:
+      lines.append(
+        f"Of those who clicked, {phished} went further and submitted credentials or took a harmful action."
+      )
+
+    return subsection("Phishing Exposure", cards + callout(*lines))
+
+  @staticmethod
+  def _speed_block(ctx: DataContext) -> str:
+    s = ctx.global_stats
+    if s is None or s.avg_time_to_click_seconds is None:
+      return ""
+
+    avg = s.avg_time_to_click_seconds
+    avg_str = fmt_seconds(avg)
+
+    if avg < 60:
+      interpretation = (
+        f"Employees who clicked did so within <strong>{avg_str}</strong> on average — under 1 minute. "
+        "This indicates <strong>reflexive, uncritical behavior</strong>: emails were acted on without "
+        "checking the sender or destination link. Highest-risk response profile."
+      )
+      risk_label, risk_level = "Critical", "red"
+    elif avg < 300:
+      interpretation = (
+        f"Employees who clicked did so within <strong>{avg_str}</strong> on average. "
+        "Responses under 5 minutes suggest <strong>limited scrutiny</strong> before acting. "
+        "Training should reinforce the 'pause and verify' habit before clicking any link."
+      )
+      risk_label, risk_level = "Elevated", "amber"
+    else:
+      interpretation = (
+        f"Employees who clicked did so after <strong>{avg_str}</strong> on average. "
+        "Longer response times indicate <strong>some consideration</strong> before acting — "
+        "a positive signal, though susceptibility remains. Continue reinforcing verification steps."
+      )
+      risk_label, risk_level = "Moderate", "amber"
+
+    return subsection(
+      "Speed of Compromise",
+      callout(interpretation, f"Response risk level: {badge(risk_label, risk_level)}"),
+    )
+
+  @staticmethod
+  def _campaign_risk_breakdown(ctx: DataContext) -> str:
+    if not ctx.campaign_details:
+      return ""
+    ranked = sorted(ctx.campaign_details, key=lambda c: c.phish_rate, reverse=True)[:5]
+    rows = [
+      [
+        c.name,
+        str(c.total_recipients),
+        f"{c.phish_rate:.1f}%",
+        f"{c.click_rate:.1f}%",
+        fmt_seconds(c.avg_time_to_click_seconds),
+      ]
+      for c in ranked
+    ]
+    return subsection(
+      "Simulation Risk Breakdown",
+      table(
+        ["Simulation", "Recipients", "Fell for Sim.", "Clicked", "Avg. Click Time"],
+        rows,
+        num_cols=frozenset({1, 2, 3}),
+      ),
+    )
+
+  @staticmethod
+  def _scores_block(m: RiskMetrics) -> str:
+    if not any([m.knowledge_score, m.sentiment_score, m.involvement_score]):
+      desc_rows = [
+        ["Knowledge", "Security threat awareness and recognition of best practices"],
+        ["Sentiment", "Employee attitudes and confidence around security policies"],
+        ["Engagement", "Active participation in security activities and training"],
+      ]
+      return subsection(
+        "Awareness Assessment",
+        callout(
+          "Awareness scoring is pending for this period. "
+          "Scores will populate as K/S/E assessment data is collected."
+        ),
+        table(["Score", "Measures"], desc_rows),
+      )
+
+    cards = stat_row(
+      [
+        ("Knowledge", f"{m.knowledge_score:.1f} / 100", "Threat awareness"),
+        ("Sentiment", f"{m.sentiment_score:.1f} / 100", "Security attitudes"),
+        ("Engagement", f"{m.involvement_score:.1f} / 100", "Active participation"),
+        ("Overall", f"{m.overall_score:.1f} / 100", "Combined average"),
+      ],
+      accent=frozenset({3}),
+    )
+    return subsection(
+      "Awareness Assessment",
+      cards,
+      callout(f"<strong>Current risk level:</strong> {m.risk_level}", f"<em>{m.notes}</em>"),
+    )
+
+  @staticmethod
+  def _repeat_clickers_block(ctx: DataContext) -> str:
+    if ctx.global_stats is None:
+      return ""
+    count = len(ctx.global_stats.repeat_offenders)
+    if count == 0:
+      return subsection(
+        "Repeat Clickers",
+        callout("No employees were caught clicking on simulated phishing links more than once this period."),
+      )
+    return subsection(
+      "Repeat Clickers",
+      callout(
+        f"<strong>{count} employee{'s' if count != 1 else ''}</strong> clicked on simulated phishing links more than once.",
+        "Repeat clickers represent the highest-risk individuals. One-on-one coaching or an accelerated training module is recommended.",
+      ),
+    )
+
+  @staticmethod
+  def _risk_signals_block(ctx: DataContext) -> str:
+    s = ctx.global_stats
+    m = ctx.compliance_metrics
+
+    phish_rate = s.phish_rate if s else 0.0
+    compliance_rate = m.compliance_rate if m else 100.0
+    repeat_count = len(s.repeat_offenders) if s else 0
+
+    if phish_rate > 10:
+      phish_signal = f"{badge('High Susceptibility', 'red')} &nbsp; {phish_rate:.1f}% of simulated targets fell — above 10% threshold"
+    elif phish_rate > 5:
+      phish_signal = f"{badge('Moderate', 'amber')} &nbsp; {phish_rate:.1f}% fell — within elevated range (5–10%)"
+    else:
+      phish_signal = f"{badge('Low', 'green')} &nbsp; {phish_rate:.1f}% fell — below 5% threshold"
+
+    if compliance_rate < 70:
+      train_signal = f"{badge('Training Gap', 'red')} &nbsp; {compliance_rate:.1f}% trained — significant coverage gap"
+    elif compliance_rate < 85:
+      train_signal = f"{badge('Improving', 'amber')} &nbsp; {compliance_rate:.1f}% trained — approaching target coverage"
+    else:
+      train_signal = f"{badge('Good Coverage', 'green')} &nbsp; {compliance_rate:.1f}% trained — strong baseline"
+
+    if repeat_count > 0:
+      repeat_signal = f"{badge('Repeat Exposure', 'amber')} &nbsp; {repeat_count} employee{'s' if repeat_count != 1 else ''} clicked multiple times — targeted intervention needed"
+    else:
+      repeat_signal = f"{badge('No Repeats', 'green')} &nbsp; No repeat clickers detected this period"
+
+    bullets = "".join(
+      f'<li style="margin:0.5em 0;">{sig}</li>'
+      for sig in [phish_signal, train_signal, repeat_signal]
+    )
+    return subsection("Risk Signals", f'<ul style="list-style:none; padding:0;">{bullets}</ul>')

--- a/api/src/services/reports/service.py
+++ b/api/src/services/reports/service.py
@@ -1,0 +1,105 @@
+"""ReportService — top-level orchestrator for report generation."""
+
+from __future__ import annotations
+
+from sqlmodel import Session
+
+from src.services.reports.collectors import (
+  collect_campaign_stats,
+  collect_compliance_metrics,
+  collect_global_stats,
+  collect_risk_metrics,
+)
+from src.services.reports.context import DataContext
+from src.services.reports.pdf_converter import PdfConverter
+from src.services.reports.renderer import ReportRenderer
+from src.services.reports.spec import ReportSpec, SectionKind
+
+
+class ReportService:
+  """Orchestrates data collection, Markdown rendering, and PDF conversion.
+
+  Usage::
+
+      from src.services.reports import report_service
+
+      spec = ReportBuilder(...).build()
+      pdf_bytes = report_service.generate(spec, session)
+      html_str  = report_service.render_html(spec, session)
+  """
+
+  def __init__(
+    self,
+    renderer: ReportRenderer | None = None,
+    converter: PdfConverter | None = None,
+  ) -> None:
+    self._renderer = renderer or ReportRenderer()
+    self._converter = converter or PdfConverter()
+
+  def generate(self, spec: ReportSpec, session: Session) -> bytes:
+    """Generate a PDF report from the given spec.
+
+    Args:
+        spec: Immutable report specification produced by ReportBuilder.
+        session: SQLModel sync session (same pattern as all other services).
+
+    Returns:
+        PDF file as raw bytes.
+    """
+    ctx = self._collect(spec, session)
+    html = self._renderer.render(spec, ctx)
+    return self._converter.convert(html)
+
+  def render_html(self, spec: ReportSpec, session: Session) -> str:
+    """Return the HTML document string without converting to PDF.
+
+    Useful for previewing, testing, or future plain-HTML export.
+    """
+    ctx = self._collect(spec, session)
+    return self._renderer.render(spec, ctx)
+
+  # ------------------------------------------------------------------
+  # Private
+  # ------------------------------------------------------------------
+
+  def _collect(self, spec: ReportSpec, session: Session) -> DataContext:
+    """Run all required collectors and assemble a DataContext."""
+    kinds = {sc.kind for sc in spec.sections}
+
+    # Gather global stats if any section needs them
+    global_stats = (
+      collect_global_stats(spec.realm_name, session)
+      if SectionKind.GLOBAL_STATS in kinds or SectionKind.RISK in kinds
+      else None
+    )
+
+    # Gather per-campaign stats only if a CAMPAIGN_STATS section is present
+    campaign_details = []
+    for section in spec.sections:
+      if section.kind == SectionKind.CAMPAIGN_STATS:
+        campaign_details = collect_campaign_stats(section.campaign_ids, session)
+        break
+
+    # Risk metrics (placeholder impl)
+    risk_metrics = (
+      collect_risk_metrics(spec.realm_name)
+      if SectionKind.RISK in kinds
+      else None
+    )
+
+    # Compliance metrics
+    compliance_metrics = (
+      collect_compliance_metrics(spec.realm_name, session)
+      if SectionKind.COMPLIANCE in kinds
+      else None
+    )
+
+    from src.services.reports.context import RiskMetrics  # avoid circular at module level
+    return DataContext(
+      realm_name=spec.realm_name,
+      generated_at=spec.generated_at,
+      global_stats=global_stats,
+      campaign_details=campaign_details,
+      risk_metrics=risk_metrics or RiskMetrics(),
+      compliance_metrics=compliance_metrics,
+    )

--- a/api/src/services/reports/spec.py
+++ b/api/src/services/reports/spec.py
@@ -1,0 +1,41 @@
+"""Report specification data models — the configuration layer for report generation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SectionKind(StrEnum):
+  RISK = "risk"
+  GLOBAL_STATS = "global_stats"
+  CAMPAIGN_STATS = "campaign_stats"
+  COMPLIANCE = "compliance"
+  EXECUTIVE_SUMMARY = "executive_summary"
+  RISK_OUTLOOK = "risk_outlook"
+  OPERATIONS_OUTLOOK = "operations_outlook"
+
+
+class SectionConfig(BaseModel):
+  """Configuration for a single report section."""
+
+  kind: SectionKind
+  # campaign_ids is only consumed by CAMPAIGN_STATS; ignored by other sections
+  campaign_ids: list[int] = []
+  # options is reserved for future per-section tuning (e.g. top-N limits)
+  options: dict[str, Any] = {}
+
+
+class ReportSpec(BaseModel):
+  """Immutable description of what a generated report should contain."""
+
+  model_config = ConfigDict(frozen=True)
+
+  title: str
+  realm_name: str
+  generated_at: datetime
+  # Ordered tuple so callers control section order and the spec stays hashable
+  sections: tuple[SectionConfig, ...]

--- a/api/test/services/reports/collectors/test_campaign_stats_collector.py
+++ b/api/test/services/reports/collectors/test_campaign_stats_collector.py
@@ -1,0 +1,62 @@
+"""Tests for the campaign stats collector."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.models import CampaignDetailInfo
+from src.services.reports.collectors.campaign_stats import collect_campaign_stats
+
+
+class TestCampaignStatsCollector:
+  def test_returns_empty_list_for_empty_ids(self):
+    result = collect_campaign_stats([], session=MagicMock())
+    assert result == []
+
+  def test_returns_list_of_detail_info(self, mock_campaign_detail):
+    mock_campaign = MagicMock()
+    mock_handler = MagicMock()
+    mock_handler._to_detail_info.return_value = mock_campaign_detail
+
+    session = MagicMock()
+    session.exec.return_value.all.return_value = [mock_campaign]
+
+    with patch(
+      "src.services.reports.collectors.campaign_stats.get_stats_handler",
+      return_value=mock_handler,
+    ):
+      result = collect_campaign_stats([1], session)
+
+    assert len(result) == 1
+    assert result[0] is mock_campaign_detail
+
+  def test_calls_to_detail_info_once_per_campaign(self, mock_campaign_detail):
+    mock_campaigns = [MagicMock(), MagicMock()]
+    mock_handler = MagicMock()
+    mock_handler._to_detail_info.return_value = mock_campaign_detail
+
+    session = MagicMock()
+    session.exec.return_value.all.return_value = mock_campaigns
+
+    with patch(
+      "src.services.reports.collectors.campaign_stats.get_stats_handler",
+      return_value=mock_handler,
+    ):
+      collect_campaign_stats([1, 2], session)
+
+    assert mock_handler._to_detail_info.call_count == 2
+
+  def test_skips_missing_campaigns_gracefully(self):
+    session = MagicMock()
+    session.exec.return_value.all.return_value = []  # nothing found
+
+    mock_handler = MagicMock()
+    with patch(
+      "src.services.reports.collectors.campaign_stats.get_stats_handler",
+      return_value=mock_handler,
+    ):
+      result = collect_campaign_stats([999], session)
+
+    assert result == []

--- a/api/test/services/reports/collectors/test_compliance_collector.py
+++ b/api/test/services/reports/collectors/test_compliance_collector.py
@@ -1,0 +1,82 @@
+"""Tests for the compliance metrics collector."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.services.reports.collectors.compliance import collect_compliance_metrics
+from src.services.reports.context import ComplianceMetrics
+
+
+def _make_record(user_id: str, score: int = 85):
+  rec = MagicMock()
+  rec.user_identifier = user_id
+  rec.score = score
+  return rec
+
+
+class TestComplianceCollector:
+  def test_returns_compliance_metrics(self):
+    session = MagicMock()
+    session.exec.return_value.all.return_value = []
+    result = collect_compliance_metrics("acme", session)
+    assert isinstance(result, ComplianceMetrics)
+
+  def test_empty_records_returns_zero_metrics(self):
+    session = MagicMock()
+    session.exec.return_value.all.return_value = []
+    result = collect_compliance_metrics("acme", session)
+    assert result.total_users == 0
+    assert result.compliance_rate == 0.0
+    assert result.avg_score == 0.0
+
+  def test_calculates_compliant_users(self):
+    records = [_make_record("u1", score=80), _make_record("u2", score=0)]
+    session = MagicMock()
+    session.exec.return_value.all.return_value = records
+    result = collect_compliance_metrics("acme", session)
+    assert result.total_users == 2
+    assert result.compliant_users == 1
+
+  def test_calculates_compliance_rate(self):
+    records = [_make_record("u1", 80), _make_record("u2", 90)]
+    session = MagicMock()
+    session.exec.return_value.all.return_value = records
+    result = collect_compliance_metrics("acme", session)
+    assert result.compliance_rate == 100.0
+
+  def test_calculates_avg_score(self):
+    records = [_make_record("u1", 80), _make_record("u2", 100)]
+    session = MagicMock()
+    session.exec.return_value.all.return_value = records
+    result = collect_compliance_metrics("acme", session)
+    assert result.avg_score == 90.0
+
+  def test_calculates_avg_attempts_single_per_user(self):
+    records = [_make_record("u1"), _make_record("u2")]
+    session = MagicMock()
+    session.exec.return_value.all.return_value = records
+    result = collect_compliance_metrics("acme", session)
+    assert result.avg_attempts_to_pass == 1.0
+
+  def test_calculates_avg_attempts_multiple_per_user(self):
+    # u1 appears 3 times (3 attempts), u2 appears once
+    records = [
+      _make_record("u1"), _make_record("u1"), _make_record("u1"),
+      _make_record("u2"),
+    ]
+    session = MagicMock()
+    session.exec.return_value.all.return_value = records
+    result = collect_compliance_metrics("acme", session)
+    # mean([3, 1]) = 2.0
+    assert result.avg_attempts_to_pass == 2.0
+
+  def test_total_users_counts_unique_identifiers(self):
+    records = [_make_record("u1"), _make_record("u1"), _make_record("u2")]
+    session = MagicMock()
+    session.exec.return_value.all.return_value = records
+    result = collect_compliance_metrics("acme", session)
+    assert result.total_users == 2

--- a/api/test/services/reports/collectors/test_global_stats_collector.py
+++ b/api/test/services/reports/collectors/test_global_stats_collector.py
@@ -1,0 +1,49 @@
+"""Tests for the global stats collector."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.models import CampaignGlobalStats
+from src.services.reports.collectors.global_stats import collect_global_stats
+
+
+class TestGlobalStatsCollector:
+  def test_returns_campaign_global_stats(self, mock_global_stats):
+    mock_handler = MagicMock()
+    mock_handler.get_global_stats.return_value = mock_global_stats
+
+    with patch(
+      "src.services.reports.collectors.global_stats.get_stats_handler",
+      return_value=mock_handler,
+    ):
+      result = collect_global_stats("acme", session=MagicMock())
+
+    assert isinstance(result, CampaignGlobalStats)
+
+  def test_calls_handler_with_realm_and_session(self, mock_global_stats):
+    session = MagicMock()
+    mock_handler = MagicMock()
+    mock_handler.get_global_stats.return_value = mock_global_stats
+
+    with patch(
+      "src.services.reports.collectors.global_stats.get_stats_handler",
+      return_value=mock_handler,
+    ):
+      collect_global_stats("acme", session)
+
+    mock_handler.get_global_stats.assert_called_once_with("acme", session)
+
+  def test_returns_correct_total_campaigns(self, mock_global_stats):
+    mock_handler = MagicMock()
+    mock_handler.get_global_stats.return_value = mock_global_stats
+
+    with patch(
+      "src.services.reports.collectors.global_stats.get_stats_handler",
+      return_value=mock_handler,
+    ):
+      result = collect_global_stats("acme", session=MagicMock())
+
+    assert result.total_campaigns == 5

--- a/api/test/services/reports/collectors/test_risk_collector.py
+++ b/api/test/services/reports/collectors/test_risk_collector.py
@@ -1,0 +1,36 @@
+"""Tests for the risk collector."""
+
+from __future__ import annotations
+
+from src.services.reports.collectors.risk import collect_risk_metrics
+from src.services.reports.context import RiskMetrics
+
+
+class TestRiskCollector:
+  def test_returns_risk_metrics(self):
+    result = collect_risk_metrics("acme")
+    assert isinstance(result, RiskMetrics)
+
+  def test_scores_are_placeholder_zeros(self):
+    result = collect_risk_metrics("acme")
+    assert result.knowledge_score == 0.0
+    assert result.sentiment_score == 0.0
+    assert result.involvement_score == 0.0
+
+  def test_overall_score_computed_from_components(self):
+    result = collect_risk_metrics("acme")
+    # With all zeros, overall should be 0.0
+    assert result.overall_score == 0.0
+
+  def test_risk_level_is_na(self):
+    result = collect_risk_metrics("acme")
+    assert result.risk_level == "N/A"
+
+  def test_notes_indicate_pending(self):
+    result = collect_risk_metrics("acme")
+    assert "pending" in result.notes.lower()
+
+  def test_different_realms_return_same_shape(self):
+    r1 = collect_risk_metrics("realm-a")
+    r2 = collect_risk_metrics("realm-b")
+    assert r1.knowledge_score == r2.knowledge_score

--- a/api/test/services/reports/conftest.py
+++ b/api/test/services/reports/conftest.py
@@ -1,0 +1,149 @@
+"""Shared fixtures for the reports service test suite."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from src.models import CampaignDetailInfo, CampaignGlobalStats, CampaignStatus
+from src.services.reports.builder import ReportBuilder
+from src.services.reports.context import ComplianceMetrics, DataContext, RiskMetrics
+from src.services.reports.spec import ReportSpec, SectionConfig, SectionKind
+
+
+# ------------------------------------------------------------------
+# Stat fixtures
+# ------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_global_stats() -> CampaignGlobalStats:
+  return CampaignGlobalStats(
+    total_campaigns=5,
+    scheduled_campaigns=1,
+    running_campaigns=2,
+    completed_campaigns=2,
+    canceled_campaigns=0,
+    total_emails_scheduled=1000,
+    total_emails_sent=900,
+    total_emails_opened=450,
+    total_emails_clicked=200,
+    total_emails_phished=80,
+    total_emails_failed=10,
+    delivery_rate=90.0,
+    open_rate=50.0,
+    click_rate=22.2,
+    phish_rate=8.9,
+    unique_users_targeted=300,
+    users_who_opened=200,
+    users_who_clicked=100,
+    users_who_phished=40,
+    repeat_offenders=["user-1", "user-2"],
+    avg_time_to_open_seconds=120.5,
+    avg_time_to_click_seconds=300.0,
+  )
+
+
+@pytest.fixture()
+def mock_campaign_detail() -> CampaignDetailInfo:
+  return CampaignDetailInfo(
+    id=1,
+    name="Test Campaign",
+    description="A test phishing campaign",
+    begin_date=datetime(2025, 1, 1, 9, 0),
+    end_date=datetime(2025, 1, 31, 18, 0),
+    sending_interval_seconds=3600,
+    status=CampaignStatus.COMPLETED,
+    realm_name="acme",
+    user_group_ids=["group-a"],
+    phishing_kit_ids=[10],
+    sending_profile_ids=[5],
+    phishing_kit_names=["Kit Alpha"],
+    sending_profile_names=["Profile A"],
+    total_recipients=200,
+    total_sent=190,
+    total_opened=95,
+    total_clicked=40,
+    total_phished=15,
+    total_failed=5,
+    delivery_rate=95.0,
+    open_rate=50.0,
+    click_rate=21.1,
+    phish_rate=7.9,
+    progress_percentage=100.0,
+    time_elapsed_percentage=100.0,
+    avg_time_to_open_seconds=90.0,
+    avg_time_to_click_seconds=240.0,
+    first_open_at=datetime(2025, 1, 2),
+    last_open_at=datetime(2025, 1, 28),
+    first_click_at=datetime(2025, 1, 3),
+    last_click_at=datetime(2025, 1, 27),
+  )
+
+
+@pytest.fixture()
+def mock_risk_metrics() -> RiskMetrics:
+  return RiskMetrics(
+    knowledge_score=0.0,
+    sentiment_score=0.0,
+    involvement_score=0.0,
+    risk_level="N/A",
+    notes="Risk calculation pending K/S/E data integration.",
+  )
+
+
+@pytest.fixture()
+def mock_compliance_metrics() -> ComplianceMetrics:
+  return ComplianceMetrics(
+    total_users=50,
+    compliant_users=40,
+    compliance_rate=80.0,
+    avg_score=82.5,
+    avg_attempts_to_pass=1.4,
+  )
+
+
+@pytest.fixture()
+def mock_data_context(
+  mock_global_stats: CampaignGlobalStats,
+  mock_campaign_detail: CampaignDetailInfo,
+  mock_risk_metrics: RiskMetrics,
+  mock_compliance_metrics: ComplianceMetrics,
+) -> DataContext:
+  return DataContext(
+    realm_name="acme",
+    generated_at=datetime(2025, 4, 1, 12, 0),
+    global_stats=mock_global_stats,
+    campaign_details=[mock_campaign_detail],
+    risk_metrics=mock_risk_metrics,
+    compliance_metrics=mock_compliance_metrics,
+  )
+
+
+# ------------------------------------------------------------------
+# Spec fixtures
+# ------------------------------------------------------------------
+
+
+@pytest.fixture()
+def minimal_spec() -> ReportSpec:
+  """A spec with just the risk section."""
+  return (
+    ReportBuilder(title="Minimal Report", realm_name="acme")
+    .add_risk_report()
+    .build()
+  )
+
+
+@pytest.fixture()
+def full_spec() -> ReportSpec:
+  """A spec containing all four sections."""
+  return (
+    ReportBuilder(title="Full Report", realm_name="acme")
+    .add_risk_report()
+    .add_global_stats()
+    .add_campaign_stats(campaign_ids=[1])
+    .add_compliance()
+    .build()
+  )

--- a/api/test/services/reports/sections/test_campaign_stats.py
+++ b/api/test/services/reports/sections/test_campaign_stats.py
@@ -1,0 +1,67 @@
+"""Tests for CampaignStatsSection."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.reports.sections.campaign_stats import CampaignStatsSection
+from src.services.reports.spec import SectionConfig, SectionKind
+
+
+def _config(campaign_ids: list[int] | None = None) -> SectionConfig:
+  return SectionConfig(
+    kind=SectionKind.CAMPAIGN_STATS,
+    campaign_ids=campaign_ids or [],
+  )
+
+
+class TestCampaignStatsSection:
+  def test_render_contains_heading(self, mock_data_context):
+    md = CampaignStatsSection().render(_config([1]), mock_data_context)
+    assert "Simulation Campaigns" in md
+
+  def test_render_shows_campaign_name(self, mock_data_context):
+    md = CampaignStatsSection().render(_config([1]), mock_data_context)
+    assert "Test Campaign" in md
+
+  def test_render_shows_status(self, mock_data_context):
+    md = CampaignStatsSection().render(_config([1]), mock_data_context)
+    assert "completed" in md.lower()
+
+  def test_render_shows_delivery_rate(self, mock_data_context):
+    md = CampaignStatsSection().render(_config([1]), mock_data_context)
+    assert "95.0%" in md
+
+  def test_render_shows_phish_rate(self, mock_data_context):
+    md = CampaignStatsSection().render(_config([1]), mock_data_context)
+    assert "7.9%" in md
+
+  def test_render_shows_avg_time_to_open_human_readable(self, mock_data_context):
+    # 90s = 1 min 30 sec
+    md = CampaignStatsSection().render(_config([1]), mock_data_context)
+    assert "1 min 30 sec" in md
+
+  def test_render_no_matching_campaign_ids(self, mock_data_context):
+    md = CampaignStatsSection().render(_config([999]), mock_data_context)
+    assert "No matching simulations" in md
+
+  def test_render_empty_campaign_details(self, mock_data_context):
+    mock_data_context.campaign_details = []
+    md = CampaignStatsSection().render(_config([1]), mock_data_context)
+    assert "No simulation data available" in md
+
+  def test_render_all_campaigns_when_no_ids_specified(self, mock_data_context):
+    md = CampaignStatsSection().render(_config([]), mock_data_context)
+    assert "Test Campaign" in md
+
+  def test_render_shows_kit_names(self, mock_data_context):
+    md = CampaignStatsSection().render(_config([1]), mock_data_context)
+    assert "Kit Alpha" in md
+
+  def test_render_shows_progress(self, mock_data_context):
+    md = CampaignStatsSection().render(_config([1]), mock_data_context)
+    assert "100.0%" in md
+
+  def test_render_uses_friendly_label_fell_for_simulation(self, mock_data_context):
+    md = CampaignStatsSection().render(_config([1]), mock_data_context)
+    assert "Fell for simulation" in md

--- a/api/test/services/reports/sections/test_compliance.py
+++ b/api/test/services/reports/sections/test_compliance.py
@@ -1,0 +1,75 @@
+"""Tests for ComplianceSection."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.reports.context import ComplianceMetrics
+from src.services.reports.sections.compliance import ComplianceSection
+from src.services.reports.spec import SectionConfig, SectionKind
+
+
+def _config() -> SectionConfig:
+  return SectionConfig(kind=SectionKind.COMPLIANCE)
+
+
+class TestComplianceSection:
+  def test_render_contains_heading(self, mock_data_context):
+    md = ComplianceSection().render(_config(), mock_data_context)
+    assert "Security Training Completion" in md
+
+  def test_render_shows_total_users(self, mock_data_context):
+    md = ComplianceSection().render(_config(), mock_data_context)
+    assert "50" in md  # total_users
+
+  def test_render_shows_compliant_users(self, mock_data_context):
+    md = ComplianceSection().render(_config(), mock_data_context)
+    assert "40" in md  # compliant_users
+
+  def test_render_shows_non_compliant_users(self, mock_data_context):
+    md = ComplianceSection().render(_config(), mock_data_context)
+    assert "10" in md  # 50 - 40
+
+  def test_render_shows_compliance_rate(self, mock_data_context):
+    md = ComplianceSection().render(_config(), mock_data_context)
+    assert "80.0%" in md
+
+  def test_render_shows_avg_score(self, mock_data_context):
+    md = ComplianceSection().render(_config(), mock_data_context)
+    assert "82.5%" in md
+
+  def test_render_shows_avg_attempts(self, mock_data_context):
+    md = ComplianceSection().render(_config(), mock_data_context)
+    assert "1.4" in md
+
+  def test_render_shows_gap_callout_when_non_compliant(self, mock_data_context):
+    md = ComplianceSection().render(_config(), mock_data_context)
+    assert "still need to complete" in md
+
+  def test_render_no_compliance_data_fallback(self, mock_data_context):
+    mock_data_context.compliance_metrics = None
+    md = ComplianceSection().render(_config(), mock_data_context)
+    assert "No training data available" in md
+
+  def test_render_zero_users_edge_case(self, mock_data_context):
+    mock_data_context.compliance_metrics = ComplianceMetrics(
+      total_users=0,
+      compliant_users=0,
+      compliance_rate=0.0,
+      avg_score=0.0,
+      avg_attempts_to_pass=0.0,
+    )
+    md = ComplianceSection().render(_config(), mock_data_context)
+    assert "Security Training Completion" in md
+    assert "0.0%" in md
+
+  def test_render_all_compliant_shows_positive_callout(self, mock_data_context):
+    mock_data_context.compliance_metrics = ComplianceMetrics(
+      total_users=50,
+      compliant_users=50,
+      compliance_rate=100.0,
+      avg_score=90.0,
+      avg_attempts_to_pass=1.1,
+    )
+    md = ComplianceSection().render(_config(), mock_data_context)
+    assert "All employees" in md

--- a/api/test/services/reports/sections/test_executive_summary.py
+++ b/api/test/services/reports/sections/test_executive_summary.py
@@ -1,0 +1,108 @@
+"""Tests for ExecutiveSummarySection."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.reports.context import ComplianceMetrics, DataContext
+from src.services.reports.sections.executive_summary import ExecutiveSummarySection, _posture
+from src.services.reports.spec import SectionConfig, SectionKind
+
+
+def _config() -> SectionConfig:
+  return SectionConfig(kind=SectionKind.EXECUTIVE_SUMMARY)
+
+
+class TestPostureHelper:
+  def test_strong_when_low_phish_and_high_compliance(self):
+    label, level = _posture(phish_rate=3.0, compliance_rate=90.0)
+    assert label == "Strong"
+    assert level == "green"
+
+  def test_improving_when_moderate(self):
+    label, level = _posture(phish_rate=7.0, compliance_rate=75.0)
+    assert label == "Improving"
+    assert level == "amber"
+
+  def test_needs_attention_when_high_phish(self):
+    label, level = _posture(phish_rate=15.0, compliance_rate=60.0)
+    assert label == "Needs Attention"
+    assert level == "red"
+
+  def test_boundary_strong_phish_threshold(self):
+    # phish_rate == 5.0 is NOT < 5, so not Strong
+    label, _ = _posture(phish_rate=5.0, compliance_rate=90.0)
+    assert label != "Strong"
+
+  def test_boundary_improving_phish_threshold(self):
+    # phish_rate == 10.0 is NOT < 10, so falls to Needs Attention
+    label, _ = _posture(phish_rate=10.0, compliance_rate=75.0)
+    assert label == "Needs Attention"
+
+
+class TestExecutiveSummarySection:
+  def test_render_contains_heading(self, mock_data_context):
+    html = ExecutiveSummarySection().render(_config(), mock_data_context)
+    assert "Executive Summary" in html
+
+  def test_render_contains_at_a_glance(self, mock_data_context):
+    html = ExecutiveSummarySection().render(_config(), mock_data_context)
+    assert "At a Glance" in html
+
+  def test_render_contains_realm_name(self, mock_data_context):
+    html = ExecutiveSummarySection().render(_config(), mock_data_context)
+    assert "acme" in html
+
+  def test_render_contains_posture_badge(self, mock_data_context):
+    html = ExecutiveSummarySection().render(_config(), mock_data_context)
+    assert "badge" in html
+
+  def test_render_contains_phish_rate(self, mock_data_context):
+    html = ExecutiveSummarySection().render(_config(), mock_data_context)
+    assert "8.9%" in html
+
+  def test_render_contains_compliance_rate(self, mock_data_context):
+    html = ExecutiveSummarySection().render(_config(), mock_data_context)
+    assert "80.0%" in html
+
+  def test_render_contains_key_findings(self, mock_data_context):
+    html = ExecutiveSummarySection().render(_config(), mock_data_context)
+    assert "Key Findings" in html
+
+  def test_render_contains_recommended_actions(self, mock_data_context):
+    html = ExecutiveSummarySection().render(_config(), mock_data_context)
+    assert "Recommended Actions" in html
+
+  def test_render_no_global_stats(self, mock_data_context):
+    mock_data_context.global_stats = None
+    html = ExecutiveSummarySection().render(_config(), mock_data_context)
+    assert "Executive Summary" in html  # still renders
+
+  def test_render_no_compliance_metrics(self, mock_data_context):
+    mock_data_context.compliance_metrics = None
+    html = ExecutiveSummarySection().render(_config(), mock_data_context)
+    assert "Executive Summary" in html
+
+  def test_render_shows_repeat_clicker_recommendation_when_present(self, mock_data_context):
+    # fixture has 2 repeat offenders
+    html = ExecutiveSummarySection().render(_config(), mock_data_context)
+    assert "coaching" in html.lower() or "repeat" in html.lower()
+
+  def test_render_shows_training_gap_recommendation_when_low_compliance(self, mock_data_context):
+    mock_data_context.compliance_metrics.compliance_rate = 50.0
+    mock_data_context.compliance_metrics.compliant_users = 25
+    html = ExecutiveSummarySection().render(_config(), mock_data_context)
+    assert "training" in html.lower()
+
+  def test_render_positive_callout_when_all_good(self, mock_data_context):
+    mock_data_context.global_stats.phish_rate = 3.0
+    mock_data_context.global_stats.repeat_offenders = []
+    mock_data_context.compliance_metrics.compliance_rate = 95.0
+    mock_data_context.compliance_metrics.compliant_users = 50
+    html = ExecutiveSummarySection().render(_config(), mock_data_context)
+    assert "momentum" in html.lower() or "strong" in html.lower()
+
+  def test_render_shows_ratio_in_findings(self, mock_data_context):
+    # clicked=100, targeted=300 → 1 in 3
+    html = ExecutiveSummarySection().render(_config(), mock_data_context)
+    assert "1 in" in html

--- a/api/test/services/reports/sections/test_global_stats.py
+++ b/api/test/services/reports/sections/test_global_stats.py
@@ -1,0 +1,63 @@
+"""Tests for GlobalStatsSection."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.reports.sections.global_stats import GlobalStatsSection
+from src.services.reports.spec import SectionConfig, SectionKind
+
+
+def _config() -> SectionConfig:
+  return SectionConfig(kind=SectionKind.GLOBAL_STATS)
+
+
+class TestGlobalStatsSection:
+  def test_render_contains_heading(self, mock_data_context):
+    md = GlobalStatsSection().render(_config(), mock_data_context)
+    assert "Phishing Simulation Summary" in md
+
+  def test_render_shows_total_campaigns(self, mock_data_context):
+    md = GlobalStatsSection().render(_config(), mock_data_context)
+    assert "5" in md  # total_campaigns
+
+  def test_render_shows_delivery_rate(self, mock_data_context):
+    md = GlobalStatsSection().render(_config(), mock_data_context)
+    assert "90.0%" in md
+
+  def test_render_shows_phish_rate(self, mock_data_context):
+    md = GlobalStatsSection().render(_config(), mock_data_context)
+    assert "8.9%" in md
+
+  def test_render_shows_email_funnel_stages(self, mock_data_context):
+    md = GlobalStatsSection().render(_config(), mock_data_context)
+    for stage in ("Scheduled", "Delivered", "Opened", "Clicked link", "Fell for simulation", "Failed to deliver"):
+      assert stage in md
+
+  def test_render_shows_repeat_clicker_count(self, mock_data_context):
+    md = GlobalStatsSection().render(_config(), mock_data_context)
+    assert "Repeat clickers" in md
+    assert "2" in md  # two repeat offenders in fixture
+    # Emails must not be exposed
+    assert "user-1" not in md
+    assert "user-2" not in md
+
+  def test_render_shows_avg_time_to_open(self, mock_data_context):
+    # 120s = 2 min 0 sec
+    md = GlobalStatsSection().render(_config(), mock_data_context)
+    assert "2 min" in md
+
+  def test_render_shows_na_when_avg_times_missing(self, mock_data_context):
+    mock_data_context.global_stats.avg_time_to_open_seconds = None
+    mock_data_context.global_stats.avg_time_to_click_seconds = None
+    md = GlobalStatsSection().render(_config(), mock_data_context)
+    assert "N/A" in md
+
+  def test_render_no_data_fallback(self, mock_data_context):
+    mock_data_context.global_stats = None
+    md = GlobalStatsSection().render(_config(), mock_data_context)
+    assert "No data available" in md
+
+  def test_render_shows_click_ratio_callout(self, mock_data_context):
+    md = GlobalStatsSection().render(_config(), mock_data_context)
+    assert "in" in md.lower()  # ratio framing: "1 in X targeted employees"

--- a/api/test/services/reports/sections/test_operations_outlook.py
+++ b/api/test/services/reports/sections/test_operations_outlook.py
@@ -1,0 +1,85 @@
+"""Tests for OperationsOutlookSection."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.reports.context import ComplianceMetrics
+from src.services.reports.sections.operations_outlook import OperationsOutlookSection
+from src.services.reports.spec import SectionConfig, SectionKind
+
+
+def _config(campaign_ids: list[int] | None = None) -> SectionConfig:
+  return SectionConfig(kind=SectionKind.OPERATIONS_OUTLOOK, campaign_ids=campaign_ids or [])
+
+
+class TestOperationsOutlookSection:
+  def test_render_contains_heading(self, mock_data_context):
+    html = OperationsOutlookSection().render(_config([1]), mock_data_context)
+    assert "Operations Outlook" in html
+
+  def test_render_contains_simulation_summary(self, mock_data_context):
+    html = OperationsOutlookSection().render(_config([1]), mock_data_context)
+    assert "Simulation Summary" in html
+
+  def test_render_shows_email_funnel(self, mock_data_context):
+    html = OperationsOutlookSection().render(_config([1]), mock_data_context)
+    assert "Delivered" in html
+    assert "Fell for Simulation" in html
+
+  def test_render_shows_campaign_detail(self, mock_data_context):
+    html = OperationsOutlookSection().render(_config([1]), mock_data_context)
+    assert "Campaign Detail" in html
+    assert "Test Campaign" in html
+
+  def test_render_shows_compliance_detail(self, mock_data_context):
+    html = OperationsOutlookSection().render(_config([1]), mock_data_context)
+    assert "Training Completion" in html
+    assert "80.0%" in html
+
+  def test_render_no_global_stats_fallback(self, mock_data_context):
+    mock_data_context.global_stats = None
+    html = OperationsOutlookSection().render(_config([1]), mock_data_context)
+    assert "No simulation data available" in html
+
+  def test_render_no_campaign_details_fallback(self, mock_data_context):
+    mock_data_context.campaign_details = []
+    html = OperationsOutlookSection().render(_config([1]), mock_data_context)
+    assert "No campaign data available" in html
+
+  def test_render_no_compliance_metrics_fallback(self, mock_data_context):
+    mock_data_context.compliance_metrics = None
+    html = OperationsOutlookSection().render(_config([1]), mock_data_context)
+    assert "No training data available" in html
+
+  def test_render_no_matching_campaign_ids_fallback(self, mock_data_context):
+    html = OperationsOutlookSection().render(_config([999]), mock_data_context)
+    assert "No matching campaigns found" in html
+
+  def test_render_all_campaigns_when_no_ids(self, mock_data_context):
+    html = OperationsOutlookSection().render(_config([]), mock_data_context)
+    assert "Test Campaign" in html
+
+  def test_render_shows_gap_callout_when_non_compliant(self, mock_data_context):
+    html = OperationsOutlookSection().render(_config([1]), mock_data_context)
+    assert "still need to complete" in html
+
+  def test_render_shows_ratio_callout(self, mock_data_context):
+    html = OperationsOutlookSection().render(_config([1]), mock_data_context)
+    assert "in" in html  # ratio framing
+
+  def test_render_all_compliant_positive_callout(self, mock_data_context):
+    mock_data_context.compliance_metrics = ComplianceMetrics(
+      total_users=50,
+      compliant_users=50,
+      compliance_rate=100.0,
+      avg_score=95.0,
+      avg_attempts_to_pass=1.0,
+    )
+    html = OperationsOutlookSection().render(_config([1]), mock_data_context)
+    assert "All employees" in html
+
+  def test_render_shows_human_readable_timing(self, mock_data_context):
+    # avg_time_to_open_seconds=90.0 → "1 min 30 sec"
+    html = OperationsOutlookSection().render(_config([1]), mock_data_context)
+    assert "1 min 30 sec" in html

--- a/api/test/services/reports/sections/test_risk.py
+++ b/api/test/services/reports/sections/test_risk.py
@@ -1,0 +1,96 @@
+"""Tests for RiskReportSection."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.reports.context import DataContext, RiskMetrics
+from src.services.reports.sections.risk import RiskReportSection
+from src.services.reports.spec import SectionConfig, SectionKind
+
+
+def _config() -> SectionConfig:
+  return SectionConfig(kind=SectionKind.RISK)
+
+
+class TestRiskReportSection:
+  def test_render_contains_risk_heading(self, mock_data_context):
+    md = RiskReportSection().render(_config(), mock_data_context)
+    assert "Security Awareness Score" in md
+
+  def test_render_hides_scores_when_all_zero(self, mock_data_context):
+    # Default fixture has all 0.0 scores — table should be hidden
+    md = RiskReportSection().render(_config(), mock_data_context)
+    assert "Awareness scoring is pending" in md
+
+  def test_render_contains_knowledge_row_when_scores_populated(self, mock_data_context):
+    mock_data_context.risk_metrics.knowledge_score = 60.0
+    mock_data_context.risk_metrics.sentiment_score = 80.0
+    mock_data_context.risk_metrics.involvement_score = 70.0
+    mock_data_context.risk_metrics.overall_score = 70.0
+    md = RiskReportSection().render(_config(), mock_data_context)
+    assert "Knowledge Score" in md
+
+  def test_render_contains_sentiment_row_when_scores_populated(self, mock_data_context):
+    mock_data_context.risk_metrics.knowledge_score = 60.0
+    mock_data_context.risk_metrics.sentiment_score = 80.0
+    mock_data_context.risk_metrics.involvement_score = 70.0
+    md = RiskReportSection().render(_config(), mock_data_context)
+    assert "Sentiment Score" in md
+
+  def test_render_contains_engagement_row_when_scores_populated(self, mock_data_context):
+    mock_data_context.risk_metrics.knowledge_score = 60.0
+    mock_data_context.risk_metrics.sentiment_score = 80.0
+    mock_data_context.risk_metrics.involvement_score = 70.0
+    md = RiskReportSection().render(_config(), mock_data_context)
+    assert "Engagement Score" in md
+
+  def test_render_contains_overall_score_when_populated(self, mock_data_context):
+    mock_data_context.risk_metrics.knowledge_score = 60.0
+    mock_data_context.risk_metrics.sentiment_score = 80.0
+    mock_data_context.risk_metrics.involvement_score = 70.0
+    mock_data_context.risk_metrics.overall_score = 70.0
+    md = RiskReportSection().render(_config(), mock_data_context)
+    assert "Overall Score" in md
+
+  def test_render_overall_score_computed_from_components(self, mock_data_context):
+    mock_data_context.risk_metrics.knowledge_score = 60.0
+    mock_data_context.risk_metrics.sentiment_score = 80.0
+    mock_data_context.risk_metrics.involvement_score = 70.0
+    mock_data_context.risk_metrics.overall_score = 70.0
+    md = RiskReportSection().render(_config(), mock_data_context)
+    assert "70.0" in md
+
+  def test_render_shows_repeat_offenders_count(self, mock_data_context):
+    # Emails must NOT appear; only the count is shown
+    md = RiskReportSection().render(_config(), mock_data_context)
+    assert "user-1" not in md
+    assert "user-2" not in md
+    assert "2" in md  # count of repeat offenders
+
+  def test_render_no_repeat_offenders_message(self, mock_data_context):
+    mock_data_context.global_stats.repeat_offenders = []
+    md = RiskReportSection().render(_config(), mock_data_context)
+    assert "No repeat clickers" in md
+
+  def test_render_shows_top_vulnerable_campaigns(self, mock_data_context):
+    md = RiskReportSection().render(_config(), mock_data_context)
+    assert "Test Campaign" in md
+
+  def test_render_no_campaigns_message(self, mock_data_context):
+    mock_data_context.campaign_details = []
+    md = RiskReportSection().render(_config(), mock_data_context)
+    assert "No simulation data available" in md
+
+  def test_render_no_global_stats_shows_fallback(self, mock_data_context):
+    mock_data_context.global_stats = None
+    md = RiskReportSection().render(_config(), mock_data_context)
+    assert "No simulation data available" in md
+
+  def test_render_notes_shown_when_scores_populated(self, mock_data_context):
+    mock_data_context.risk_metrics.knowledge_score = 60.0
+    mock_data_context.risk_metrics.sentiment_score = 80.0
+    mock_data_context.risk_metrics.involvement_score = 70.0
+    mock_data_context.risk_metrics.notes = "Risk calculation pending K/S/E data integration."
+    md = RiskReportSection().render(_config(), mock_data_context)
+    assert "Risk calculation pending" in md

--- a/api/test/services/reports/sections/test_risk_outlook.py
+++ b/api/test/services/reports/sections/test_risk_outlook.py
@@ -1,0 +1,98 @@
+"""Tests for RiskOutlookSection."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.reports.sections.risk_outlook import RiskOutlookSection
+from src.services.reports.spec import SectionConfig, SectionKind
+
+
+def _config() -> SectionConfig:
+  return SectionConfig(kind=SectionKind.RISK_OUTLOOK)
+
+
+class TestRiskOutlookSection:
+  def test_render_contains_heading(self, mock_data_context):
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "Risk Outlook" in html
+
+  def test_render_contains_phishing_exposure_block(self, mock_data_context):
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "Phishing Exposure" in html
+
+  def test_render_shows_click_ratio(self, mock_data_context):
+    # clicked=100, targeted=300 → 1 in 3
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "1 in 3" in html
+
+  def test_render_shows_benchmark_comparison(self, mock_data_context):
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "benchmark" in html.lower() or "industry" in html.lower()
+
+  def test_render_hides_scores_when_all_zero(self, mock_data_context):
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "Awareness scoring is pending" in html
+
+  def test_render_shows_scores_when_populated(self, mock_data_context):
+    mock_data_context.risk_metrics.knowledge_score = 70.0
+    mock_data_context.risk_metrics.sentiment_score = 65.0
+    mock_data_context.risk_metrics.involvement_score = 80.0
+    mock_data_context.risk_metrics.overall_score = 71.7
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "Knowledge" in html
+    assert "Sentiment" in html
+    assert "Engagement" in html
+
+  def test_render_shows_repeat_clickers_count(self, mock_data_context):
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "2" in html  # count of repeat offenders
+    assert "user-1" not in html  # no PII
+
+  def test_render_no_repeat_clickers_positive_message(self, mock_data_context):
+    mock_data_context.global_stats.repeat_offenders = []
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "No employees were caught" in html
+
+  def test_render_shows_campaign_risk_breakdown(self, mock_data_context):
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "Simulation Risk Breakdown" in html
+    assert "Test Campaign" in html
+
+  def test_render_no_global_stats_fallback(self, mock_data_context):
+    mock_data_context.global_stats = None
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "No simulation data available" in html
+
+  def test_render_no_campaign_details_omits_breakdown(self, mock_data_context):
+    mock_data_context.campaign_details = []
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "Simulation Risk Breakdown" not in html
+
+  def test_render_no_clicks_positive_message(self, mock_data_context):
+    mock_data_context.global_stats.users_who_clicked = 0
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "No employees clicked" in html
+
+  def test_render_shows_speed_block(self, mock_data_context):
+    # avg_time_to_click_seconds=300.0 → "Moderate" category
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "Speed of Compromise" in html
+
+  def test_render_speed_block_hidden_when_no_time(self, mock_data_context):
+    mock_data_context.global_stats.avg_time_to_click_seconds = None
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "Speed of Compromise" not in html
+
+  def test_render_shows_risk_signals(self, mock_data_context):
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "Risk Signals" in html
+
+  def test_render_scores_show_descriptions_when_pending(self, mock_data_context):
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "Measures" in html  # description table column header
+
+  def test_render_campaign_breakdown_shows_avg_click_time(self, mock_data_context):
+    # campaign fixture has avg_time_to_click_seconds=240.0 → "4 min"
+    html = RiskOutlookSection().render(_config(), mock_data_context)
+    assert "4 min" in html

--- a/api/test/services/reports/test_builder.py
+++ b/api/test/services/reports/test_builder.py
@@ -1,0 +1,104 @@
+"""Tests for ReportBuilder."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.reports.builder import ReportBuilder
+from src.services.reports.spec import SectionKind
+
+
+class TestReportBuilder:
+  def test_build_returns_spec_with_correct_title(self):
+    spec = ReportBuilder(title="My Report", realm_name="test").build()
+    assert spec.title == "My Report"
+
+  def test_build_returns_spec_with_correct_realm(self):
+    spec = ReportBuilder(title="R", realm_name="acme").build()
+    assert spec.realm_name == "acme"
+
+  def test_adds_risk_section(self):
+    spec = ReportBuilder("R", "t").add_risk_report().build()
+    assert len(spec.sections) == 1
+    assert spec.sections[0].kind == SectionKind.RISK
+
+  def test_adds_global_stats_section(self):
+    spec = ReportBuilder("R", "t").add_global_stats().build()
+    assert spec.sections[0].kind == SectionKind.GLOBAL_STATS
+
+  def test_adds_campaign_stats_section_with_ids(self):
+    spec = ReportBuilder("R", "t").add_campaign_stats(campaign_ids=[1, 2]).build()
+    assert spec.sections[0].kind == SectionKind.CAMPAIGN_STATS
+    assert spec.sections[0].campaign_ids == [1, 2]
+
+  def test_adds_compliance_section(self):
+    spec = ReportBuilder("R", "t").add_compliance().build()
+    assert spec.sections[0].kind == SectionKind.COMPLIANCE
+
+  def test_section_order_preserved(self):
+    spec = (
+      ReportBuilder("R", "t")
+      .add_risk_report()
+      .add_global_stats()
+      .add_campaign_stats([])
+      .add_compliance()
+      .build()
+    )
+    kinds = [s.kind for s in spec.sections]
+    assert kinds == [
+      SectionKind.RISK,
+      SectionKind.GLOBAL_STATS,
+      SectionKind.CAMPAIGN_STATS,
+      SectionKind.COMPLIANCE,
+    ]
+
+  def test_build_produces_immutable_spec(self):
+    spec = ReportBuilder("R", "t").add_risk_report().build()
+    with pytest.raises(Exception):
+      spec.title = "mutated"  # type: ignore[misc]
+
+  def test_chaining_returns_builder(self):
+    builder = ReportBuilder("R", "t")
+    result = builder.add_risk_report()
+    assert result is builder
+
+  def test_empty_spec_has_no_sections(self):
+    spec = ReportBuilder("R", "t").build()
+    assert len(spec.sections) == 0
+
+  def test_generated_at_is_set(self):
+    spec = ReportBuilder("R", "t").build()
+    assert spec.generated_at is not None
+
+  def test_adds_executive_summary_section(self):
+    spec = ReportBuilder("R", "t").add_executive_summary().build()
+    assert spec.sections[0].kind == SectionKind.EXECUTIVE_SUMMARY
+
+  def test_adds_risk_outlook_section(self):
+    spec = ReportBuilder("R", "t").add_risk_outlook().build()
+    assert spec.sections[0].kind == SectionKind.RISK_OUTLOOK
+
+  def test_adds_operations_outlook_section_with_ids(self):
+    spec = ReportBuilder("R", "t").add_operations_outlook(campaign_ids=[1, 2]).build()
+    assert spec.sections[0].kind == SectionKind.OPERATIONS_OUTLOOK
+    assert spec.sections[0].campaign_ids == [1, 2]
+
+  def test_adds_operations_outlook_section_no_ids(self):
+    spec = ReportBuilder("R", "t").add_operations_outlook().build()
+    assert spec.sections[0].kind == SectionKind.OPERATIONS_OUTLOOK
+    assert spec.sections[0].campaign_ids == []
+
+  def test_executive_layout_order_preserved(self):
+    spec = (
+      ReportBuilder("R", "t")
+      .add_executive_summary()
+      .add_risk_outlook()
+      .add_operations_outlook(campaign_ids=[1])
+      .build()
+    )
+    kinds = [s.kind for s in spec.sections]
+    assert kinds == [
+      SectionKind.EXECUTIVE_SUMMARY,
+      SectionKind.RISK_OUTLOOK,
+      SectionKind.OPERATIONS_OUTLOOK,
+    ]

--- a/api/test/services/reports/test_pdf_converter.py
+++ b/api/test/services/reports/test_pdf_converter.py
@@ -1,0 +1,42 @@
+"""Tests for PdfConverter — WeasyPrint HTML → PDF."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.services.reports.pdf_converter import PdfConverter
+
+
+SAMPLE_HTML = "<!DOCTYPE html><html><head></head><body><h1>Test</h1></body></html>"
+
+
+class TestPdfConverter:
+  def test_convert_calls_weasyprint(self):
+    fake_pdf = b"%PDF-1.4 fake"
+    mock_html_cls = MagicMock()
+    mock_html_cls.return_value.write_pdf.return_value = fake_pdf
+
+    with patch.dict(__import__("sys").modules, {"weasyprint": MagicMock(HTML=mock_html_cls)}):
+      result = PdfConverter().convert(SAMPLE_HTML)
+
+    mock_html_cls.assert_called_once_with(string=SAMPLE_HTML)
+    mock_html_cls.return_value.write_pdf.assert_called_once()
+    assert result == fake_pdf
+
+  def test_convert_returns_bytes(self):
+    fake_pdf = b"%PDF-1.4"
+    mock_html_cls = MagicMock()
+    mock_html_cls.return_value.write_pdf.return_value = fake_pdf
+
+    with patch.dict(__import__("sys").modules, {"weasyprint": MagicMock(HTML=mock_html_cls)}):
+      result = PdfConverter().convert(SAMPLE_HTML)
+
+    assert isinstance(result, bytes)
+
+  def test_convert_raises_on_missing_weasyprint(self):
+    with patch.dict(__import__("sys").modules, {"weasyprint": None}):
+      converter = PdfConverter()
+      with pytest.raises((RuntimeError, ImportError)):
+        converter.convert(SAMPLE_HTML)

--- a/api/test/services/reports/test_renderer.py
+++ b/api/test/services/reports/test_renderer.py
@@ -1,0 +1,69 @@
+"""Tests for ReportRenderer — HTML output."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from src.services.reports.context import DataContext, RiskMetrics
+from src.services.reports.renderer import ReportRenderer
+from src.services.reports.spec import SectionKind
+
+
+class TestReportRenderer:
+  def test_render_contains_title(self, full_spec, mock_data_context):
+    html = ReportRenderer().render(full_spec, mock_data_context)
+    assert "Full Report" in html
+
+  def test_render_contains_realm(self, full_spec, mock_data_context):
+    html = ReportRenderer().render(full_spec, mock_data_context)
+    assert "acme" in html
+
+  def test_render_contains_footer(self, full_spec, mock_data_context):
+    html = ReportRenderer().render(full_spec, mock_data_context)
+    assert "SecureLearning" in html
+
+  def test_render_is_valid_html_document(self, full_spec, mock_data_context):
+    html = ReportRenderer().render(full_spec, mock_data_context)
+    assert html.startswith("<!DOCTYPE html>")
+    assert "<html" in html
+    assert "</html>" in html
+
+  def test_render_includes_risk_section_heading(self, full_spec, mock_data_context):
+    html = ReportRenderer().render(full_spec, mock_data_context)
+    assert "Security Awareness Score" in html
+
+  def test_render_includes_global_stats_heading(self, full_spec, mock_data_context):
+    html = ReportRenderer().render(full_spec, mock_data_context)
+    assert "Phishing Simulation Summary" in html
+
+  def test_render_includes_campaign_stats_heading(self, full_spec, mock_data_context):
+    html = ReportRenderer().render(full_spec, mock_data_context)
+    assert "Simulation Campaigns" in html
+
+  def test_render_includes_compliance_heading(self, full_spec, mock_data_context):
+    html = ReportRenderer().render(full_spec, mock_data_context)
+    assert "Security Training Completion" in html
+
+  def test_render_minimal_spec_only_risk(self, minimal_spec, mock_data_context):
+    html = ReportRenderer().render(minimal_spec, mock_data_context)
+    assert "Security Awareness Score" in html
+    assert "Phishing Simulation Summary" not in html
+
+  def test_render_unknown_section_kind(self, mock_data_context):
+    from src.services.reports import renderer as renderer_module
+    from src.services.reports.spec import SectionConfig, ReportSpec, SectionKind
+    from datetime import datetime
+
+    spec = ReportSpec(
+      title="T",
+      realm_name="r",
+      generated_at=datetime(2025, 1, 1),
+      sections=(SectionConfig(kind=SectionKind.COMPLIANCE),),
+    )
+    with patch.object(renderer_module, "_SECTION_REGISTRY", {}):
+      html = ReportRenderer().render(spec, mock_data_context)
+    assert "Unknown section" in html
+
+  def test_sections_separated_by_horizontal_rule(self, full_spec, mock_data_context):
+    html = ReportRenderer().render(full_spec, mock_data_context)
+    assert "<hr>" in html

--- a/api/test/services/reports/test_service.py
+++ b/api/test/services/reports/test_service.py
@@ -1,0 +1,83 @@
+"""Tests for ReportService."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.services.reports.builder import ReportBuilder
+from src.services.reports.context import DataContext, RiskMetrics
+from src.services.reports.service import ReportService
+
+
+def _make_service(markdown="# Mock Report\n", pdf=b"%PDF-mock"):
+  renderer = MagicMock()
+  renderer.render.return_value = markdown
+  converter = MagicMock()
+  converter.convert.return_value = pdf
+  return ReportService(renderer=renderer, converter=converter), renderer, converter
+
+
+class TestReportService:
+  def test_generate_returns_bytes(self, full_spec):
+    service, _, _ = _make_service()
+    result = service.generate(full_spec, session=MagicMock())
+    assert isinstance(result, bytes)
+
+  def test_generate_calls_renderer(self, full_spec):
+    service, renderer, _ = _make_service()
+    with patch.object(service, "_collect", return_value=MagicMock(spec=DataContext)):
+      service.generate(full_spec, session=MagicMock())
+    renderer.render.assert_called_once()
+
+  def test_generate_calls_converter(self, full_spec):
+    service, renderer, converter = _make_service()
+    with patch.object(service, "_collect", return_value=MagicMock(spec=DataContext)):
+      service.generate(full_spec, session=MagicMock())
+    converter.convert.assert_called_once_with(renderer.render.return_value)
+
+  def test_render_html_skips_converter(self, full_spec):
+    service, renderer, converter = _make_service()
+    with patch.object(service, "_collect", return_value=MagicMock(spec=DataContext)):
+      result = service.render_html(full_spec, session=MagicMock())
+    converter.convert.assert_not_called()
+    assert result == renderer.render.return_value
+
+  def test_collect_only_fetches_global_stats_when_needed(self, minimal_spec):
+    """Risk section also requires global_stats for repeat offenders."""
+    service, _, _ = _make_service()
+    session = MagicMock()
+    with (
+      patch("src.services.reports.service.collect_global_stats", return_value=MagicMock()) as mock_gs,
+      patch("src.services.reports.service.collect_campaign_stats", return_value=[]),
+      patch("src.services.reports.service.collect_risk_metrics", return_value=RiskMetrics()),
+      patch("src.services.reports.service.collect_compliance_metrics", return_value=None),
+    ):
+      service._collect(minimal_spec, session)
+    mock_gs.assert_called_once_with(minimal_spec.realm_name, session)
+
+  def test_collect_skips_compliance_when_not_in_spec(self, minimal_spec):
+    service, _, _ = _make_service()
+    session = MagicMock()
+    with (
+      patch("src.services.reports.service.collect_global_stats", return_value=MagicMock()),
+      patch("src.services.reports.service.collect_campaign_stats", return_value=[]),
+      patch("src.services.reports.service.collect_risk_metrics", return_value=RiskMetrics()),
+      patch("src.services.reports.service.collect_compliance_metrics") as mock_comp,
+    ):
+      service._collect(minimal_spec, session)
+    mock_comp.assert_not_called()
+
+  def test_collect_skips_campaign_stats_when_not_in_spec(self, minimal_spec):
+    service, _, _ = _make_service()
+    session = MagicMock()
+    with (
+      patch("src.services.reports.service.collect_global_stats", return_value=MagicMock()),
+      patch("src.services.reports.service.collect_campaign_stats") as mock_cs,
+      patch("src.services.reports.service.collect_risk_metrics", return_value=RiskMetrics()),
+      patch("src.services.reports.service.collect_compliance_metrics", return_value=None),
+    ):
+      service._collect(minimal_spec, session)
+    mock_cs.assert_not_called()

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -47,19 +47,23 @@ dependencies = [
     { name = "boto3" },
     { name = "cryptography" },
     { name = "fastapi", extra = ["all"] },
+    { name = "markdown" },
     { name = "motor" },
     { name = "pika" },
+    { name = "prometheus-fastapi-instrumentator" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pyjwt" },
     { name = "pypdf" },
     { name = "requests" },
     { name = "sqlmodel" },
+    { name = "weasyprint" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -68,19 +72,23 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.39.0" },
     { name = "cryptography", specifier = ">=46.0.3" },
     { name = "fastapi", extras = ["all"], specifier = ">=0.119.0" },
+    { name = "markdown", specifier = ">=3.10.2" },
     { name = "motor", specifier = ">=3.6.0" },
     { name = "pika", specifier = ">=1.3.0" },
+    { name = "prometheus-fastapi-instrumentator", specifier = ">=0.9.0" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.11" },
     { name = "pyjwt", specifier = ">=2.9.0" },
     { name = "pypdf" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "sqlmodel", specifier = ">=0.0.27" },
+    { name = "weasyprint", specifier = ">=68.1" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "ruff", specifier = ">=0.8.0" },
 ]
 
 [[package]]
@@ -121,6 +129,65 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/23/0c88ca116ef63b1ae77c901cd5d2095d22a8dbde9e80df74545db4a061b4/botocore-1.42.73.tar.gz", hash = "sha256:575858641e4949aaf2af1ced145b8524529edf006d075877af6b82ff96ad854c", size = 15008008, upload-time = "2026-03-20T19:39:40.082Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/65/971f3d55015f4d133a6ff3ad74cd39f4b8dd8f53f7775a3c2ad378ea5145/botocore-1.42.73-py3-none-any.whl", hash = "sha256:7b62e2a12f7a1b08eb7360eecd23bb16fe3b7ab7f5617cf91b25476c6f86a0fe", size = 14681861, upload-time = "2026-03-20T19:39:35.341Z" },
+]
+
+[[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/ee/b0a11ab2315c69bb9b45a2aaed022499c9c24a205c3a49c3513b541a7967/brotli-1.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:35d382625778834a7f3061b15423919aa03e4f5da34ac8e02c074e4b75ab4f84", size = 861543, upload-time = "2025-11-05T18:38:24.183Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2f/29c1459513cd35828e25531ebfcbf3e92a5e49f560b1777a9af7203eb46e/brotli-1.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a61c06b334bd99bc5ae84f1eeb36bfe01400264b3c352f968c6e30a10f9d08b", size = 444288, upload-time = "2025-11-05T18:38:25.139Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/feba03130d5fceadfa3a1bb102cb14650798c848b1df2a808356f939bb16/brotli-1.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acec55bb7c90f1dfc476126f9711a8e81c9af7fb617409a9ee2953115343f08d", size = 1528071, upload-time = "2025-11-05T18:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/38/f3abb554eee089bd15471057ba85f47e53a44a462cfce265d9bf7088eb09/brotli-1.2.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:260d3692396e1895c5034f204f0db022c056f9e2ac841593a4cf9426e2a3faca", size = 1626913, upload-time = "2025-11-05T18:38:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a7/03aa61fbc3c5cbf99b44d158665f9b0dd3d8059be16c460208d9e385c837/brotli-1.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:072e7624b1fc4d601036ab3f4f27942ef772887e876beff0301d261210bca97f", size = 1419762, upload-time = "2025-11-05T18:38:28.295Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/0374a89ee27d152a5069c356c96b93afd1b94eae83f1e004b57eb6ce2f10/brotli-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adedc4a67e15327dfdd04884873c6d5a01d3e3b6f61406f99b1ed4865a2f6d28", size = 1484494, upload-time = "2025-11-05T18:38:29.29Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/57/69d4fe84a67aef4f524dcd075c6eee868d7850e85bf01d778a857d8dbe0a/brotli-1.2.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7a47ce5c2288702e09dc22a44d0ee6152f2c7eda97b3c8482d826a1f3cfc7da7", size = 1593302, upload-time = "2025-11-05T18:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3b/39e13ce78a8e9a621c5df3aeb5fd181fcc8caba8c48a194cd629771f6828/brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036", size = 1487913, upload-time = "2025-11-05T18:38:31.618Z" },
+    { url = "https://files.pythonhosted.org/packages/62/28/4d00cb9bd76a6357a66fcd54b4b6d70288385584063f4b07884c1e7286ac/brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161", size = 334362, upload-time = "2025-11-05T18:38:32.939Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/4e/bc1dcac9498859d5e353c9b153627a3752868a9d5f05ce8dedd81a2354ab/brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44", size = 369115, upload-time = "2025-11-05T18:38:33.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d4/4ad5432ac98c73096159d9ce7ffeb82d151c2ac84adcc6168e476bb54674/brotli-1.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9e5825ba2c9998375530504578fd4d5d1059d09621a02065d1b6bfc41a8e05ab", size = 861523, upload-time = "2025-11-05T18:38:34.67Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9f/9cc5bd03ee68a85dc4bc89114f7067c056a3c14b3d95f171918c088bf88d/brotli-1.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0cf8c3b8ba93d496b2fae778039e2f5ecc7cff99df84df337ca31d8f2252896c", size = 444289, upload-time = "2025-11-05T18:38:35.6Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b6/fe84227c56a865d16a6614e2c4722864b380cb14b13f3e6bef441e73a85a/brotli-1.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8565e3cdc1808b1a34714b553b262c5de5fbda202285782173ec137fd13709f", size = 1528076, upload-time = "2025-11-05T18:38:36.639Z" },
+    { url = "https://files.pythonhosted.org/packages/55/de/de4ae0aaca06c790371cf6e7ee93a024f6b4bb0568727da8c3de112e726c/brotli-1.2.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:26e8d3ecb0ee458a9804f47f21b74845cc823fd1bb19f02272be70774f56e2a6", size = 1626880, upload-time = "2025-11-05T18:38:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/16/a1b22cbea436642e071adcaf8d4b350a2ad02f5e0ad0da879a1be16188a0/brotli-1.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67a91c5187e1eec76a61625c77a6c8c785650f5b576ca732bd33ef58b0dff49c", size = 1419737, upload-time = "2025-11-05T18:38:38.729Z" },
+    { url = "https://files.pythonhosted.org/packages/46/63/c968a97cbb3bdbf7f974ef5a6ab467a2879b82afbc5ffb65b8acbb744f95/brotli-1.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ecdb3b6dc36e6d6e14d3a1bdc6c1057c8cbf80db04031d566eb6080ce283a48", size = 1484440, upload-time = "2025-11-05T18:38:39.916Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/102c67ea5c9fc171f423e8399e585dabea29b5bc79b05572891e70013cdd/brotli-1.2.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3e1b35d56856f3ed326b140d3c6d9db91740f22e14b06e840fe4bb1923439a18", size = 1593313, upload-time = "2025-11-05T18:38:41.24Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/9526d14fa6b87bc827ba1755a8440e214ff90de03095cacd78a64abe2b7d/brotli-1.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54a50a9dad16b32136b2241ddea9e4df159b41247b2ce6aac0b3276a66a8f1e5", size = 1487945, upload-time = "2025-11-05T18:38:42.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e8/3fe1ffed70cbef83c5236166acaed7bb9c766509b157854c80e2f766b38c/brotli-1.2.0-cp313-cp313-win32.whl", hash = "sha256:1b1d6a4efedd53671c793be6dd760fcf2107da3a52331ad9ea429edf0902f27a", size = 334368, upload-time = "2025-11-05T18:38:43.345Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/91/e739587be970a113b37b821eae8097aac5a48e5f0eca438c22e4c7dd8648/brotli-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:b63daa43d82f0cdabf98dee215b375b4058cce72871fd07934f179885aad16e8", size = 369116, upload-time = "2025-11-05T18:38:44.609Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/298c2ddf786bb7347a1cd71d63a347a79e5712a7c0cba9e3c3458ebd976f/brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21", size = 863080, upload-time = "2025-11-05T18:38:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0c/aac98e286ba66868b2b3b50338ffbd85a35c7122e9531a73a37a29763d38/brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac", size = 445453, upload-time = "2025-11-05T18:38:46.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f1/0ca1f3f99ae300372635ab3fe2f7a79fa335fee3d874fa7f9e68575e0e62/brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e", size = 1528168, upload-time = "2025-11-05T18:38:47.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a6/2ebfc8f766d46df8d3e65b880a2e220732395e6d7dc312c1e1244b0f074a/brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7", size = 1627098, upload-time = "2025-11-05T18:38:48.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/0976d5b097ff8a22163b10617f76b2557f15f0f39d6a0fe1f02b1a53e92b/brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63", size = 1419861, upload-time = "2025-11-05T18:38:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/d76df7176a2ce7616ff94c1fb72d307c9a30d2189fe877f3dd99af00ea5a/brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b", size = 1484594, upload-time = "2025-11-05T18:38:50.655Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/93/14cf0b1216f43df5609f5b272050b0abd219e0b54ea80b47cef9867b45e7/brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361", size = 1593455, upload-time = "2025-11-05T18:38:51.624Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
+name = "brotlicffi"
+version = "1.2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/b6/017dc5f852ed9b8735af77774509271acbf1de02d238377667145fcee01d/brotlicffi-1.2.0.1.tar.gz", hash = "sha256:c20d5c596278307ad06414a6d95a892377ea274a5c6b790c2548c009385d621c", size = 478156, upload-time = "2026-03-05T19:54:11.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/f9/dfa56316837fa798eac19358351e974de8e1e2ca9475af4cb90293cd6576/brotlicffi-1.2.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c85e65913cf2b79c57a3fdd05b98d9731d9255dc0cb696b09376cc091b9cddd", size = 433046, upload-time = "2026-03-05T19:53:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f5/f8f492158c76b0d940388801f04f747028971ad5774287bded5f1e53f08d/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:535f2d05d0273408abc13fc0eebb467afac17b0ad85090c8913690d40207dac5", size = 1541126, upload-time = "2026-03-05T19:53:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e1/ff87af10ac419600c63e9287a0649c673673ae6b4f2bcf48e96cb2f89f60/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce17eb798ca59ecec67a9bb3fd7a4304e120d1cd02953ce522d959b9a84d58ac", size = 1541983, upload-time = "2026-03-05T19:53:50.317Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c0/80ecd9bd45776109fab14040e478bf63e456967c9ddee2353d8330ed8de1/brotlicffi-1.2.0.1-cp314-cp314t-win32.whl", hash = "sha256:3c9544f83cb715d95d7eab3af4adbbef8b2093ad6382288a83b3a25feb1a57ec", size = 349047, upload-time = "2026-03-05T19:53:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/98/13e5b250236a281b6cd9e92a01ee1ae231029fa78faee932ef3766e1cb24/brotlicffi-1.2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:625f8115d32ae9c0740d01ea51518437c3fbaa3e78d41cb18459f6f7ac326000", size = 385652, upload-time = "2026-03-05T19:53:53.892Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9f/b98dcd4af47994cee97aebac866996a006a2e5fc1fd1e2b82a8ad95cf09c/brotlicffi-1.2.0.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:91ba5f0ccc040f6ff8f7efaf839f797723d03ed46acb8ae9408f99ffd2572cf4", size = 432608, upload-time = "2026-03-05T19:53:56.736Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/7a/ac4ee56595a061e3718a6d1ea7e921f4df156894acffb28ed88a1fd52022/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9a670c6811af30a4bd42d7116dc5895d3b41beaa8ed8a89050447a0181f5ce", size = 1534257, upload-time = "2026-03-05T19:53:58.667Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/e7410db7f6f56de57744ea52a115084ceb2735f4d44973f349bb92136586/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3314a3476f59e5443f9f72a6dff16edc0c3463c9b318feaef04ae3e4683f5a", size = 1536838, upload-time = "2026-03-05T19:54:00.705Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/75/6e7977d1935fc3fbb201cbd619be8f2c7aea25d40a096967132854b34708/brotlicffi-1.2.0.1-cp38-abi3-win32.whl", hash = "sha256:82ea52e2b5d3145b6c406ebd3efb0d55db718b7ad996bd70c62cec0439de1187", size = 343337, upload-time = "2026-03-05T19:54:02.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ef/e7e485ce5e4ba3843a0a92feb767c7b6098fd6e65ce752918074d175ae71/brotlicffi-1.2.0.1-cp38-abi3-win_amd64.whl", hash = "sha256:da2e82a08e7778b8bc539d27ca03cdd684113e81394bfaaad8d0dfc6a17ddede", size = 379026, upload-time = "2026-03-05T19:54:04.322Z" },
 ]
 
 [[package]]
@@ -421,6 +488,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cssselect2"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tinycss2" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/20/92eaa6b0aec7189fa4b75c890640e076e9e793095721db69c5c81142c2e1/cssselect2-0.9.0.tar.gz", hash = "sha256:759aa22c216326356f65e62e791d66160a0f9c91d1424e8d8adc5e74dddfc6fb", size = 35595, upload-time = "2026-02-12T17:16:39.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/0e/8459ca4413e1a21a06c97d134bfaf18adfd27cea068813dc0faae06cbf00/cssselect2-0.9.0-py3-none-any.whl", hash = "sha256:6a99e5f91f9a016a304dd929b0966ca464bcfda15177b6fb4a118fc0fb5d9563", size = 15453, upload-time = "2026-02-12T17:16:38.317Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -584,6 +664,54 @@ wheels = [
 ]
 
 [[package]]
+name = "fonttools"
+version = "4.62.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/08/7012b00a9a5874311b639c3920270c36ee0c445b69d9989a85e5c92ebcb0/fonttools-4.62.1.tar.gz", hash = "sha256:e54c75fd6041f1122476776880f7c3c3295ffa31962dc6ebe2543c00dca58b5d", size = 3580737, upload-time = "2026-03-13T13:54:25.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/d4/dbacced3953544b9a93088cc10ef2b596d348c983d5c67a404fa41ec51ba/fonttools-4.62.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:90365821debbd7db678809c7491ca4acd1e0779b9624cdc6ddaf1f31992bf974", size = 2870219, upload-time = "2026-03-13T13:52:53.664Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9e/a769c8e99b81e5a87ab7e5e7236684de4e96246aae17274e5347d11ebd78/fonttools-4.62.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12859ff0b47dd20f110804c3e0d0970f7b832f561630cd879969011541a464a9", size = 2414891, upload-time = "2026-03-13T13:52:56.493Z" },
+    { url = "https://files.pythonhosted.org/packages/69/64/f19a9e3911968c37e1e620e14dfc5778299e1474f72f4e57c5ec771d9489/fonttools-4.62.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c125ffa00c3d9003cdaaf7f2c79e6e535628093e14b5de1dccb08859b680936", size = 5033197, upload-time = "2026-03-13T13:52:59.179Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:149f7d84afca659d1a97e39a4778794a2f83bf344c5ee5134e09995086cc2392", size = 4988768, upload-time = "2026-03-13T13:53:02.761Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/0f904540d3e6ab463c1243a0d803504826a11604c72dd58c2949796a1762/fonttools-4.62.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0aa72c43a601cfa9273bb1ae0518f1acadc01ee181a6fc60cd758d7fdadffc04", size = 4971512, upload-time = "2026-03-13T13:53:05.678Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0b/5cbef6588dc9bd6b5c9ad6a4d5a8ca384d0cea089da31711bbeb4f9654a6/fonttools-4.62.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:19177c8d96c7c36359266e571c5173bcee9157b59cfc8cb0153c5673dc5a3a7d", size = 5122723, upload-time = "2026-03-13T13:53:08.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/47/b3a5342d381595ef439adec67848bed561ab7fdb1019fa522e82101b7d9c/fonttools-4.62.1-cp312-cp312-win32.whl", hash = "sha256:a24decd24d60744ee8b4679d38e88b8303d86772053afc29b19d23bb8207803c", size = 2281278, upload-time = "2026-03-13T13:53:10.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b1/0c2ab56a16f409c6c8a68816e6af707827ad5d629634691ff60a52879792/fonttools-4.62.1-cp312-cp312-win_amd64.whl", hash = "sha256:9e7863e10b3de72376280b515d35b14f5eeed639d1aa7824f4cf06779ec65e42", size = 2331414, upload-time = "2026-03-13T13:53:13.992Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/56/6f389de21c49555553d6a5aeed5ac9767631497ac836c4f076273d15bd72/fonttools-4.62.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c22b1014017111c401469e3acc5433e6acf6ebcc6aa9efb538a533c800971c79", size = 2865155, upload-time = "2026-03-13T13:53:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c5/0e3966edd5ec668d41dfe418787726752bc07e2f5fd8c8f208615e61fa89/fonttools-4.62.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:68959f5fc58ed4599b44aad161c2837477d7f35f5f79402d97439974faebfebe", size = 2412802, upload-time = "2026-03-13T13:53:18.878Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/e6ac4b44026de7786fe46e3bfa0c87e51d5d70a841054065d49cd62bb909/fonttools-4.62.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef46db46c9447103b8f3ff91e8ba009d5fe181b1920a83757a5762551e32bb68", size = 5013926, upload-time = "2026-03-13T13:53:21.379Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/8b1e801939839d405f1f122e7d175cebe9aeb4e114f95bfc45e3152af9a7/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6706d1cb1d5e6251a97ad3c1b9347505c5615c112e66047abbef0f8545fa30d1", size = 4964575, upload-time = "2026-03-13T13:53:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/46/76/7d051671e938b1881670528fec69cc4044315edd71a229c7fd712eaa5119/fonttools-4.62.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2e7abd2b1e11736f58c1de27819e1955a53267c21732e78243fa2fa2e5c1e069", size = 4953693, upload-time = "2026-03-13T13:53:26.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ae/b41f8628ec0be3c1b934fc12b84f4576a5c646119db4d3bdd76a217c90b5/fonttools-4.62.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:403d28ce06ebfc547fbcb0cb8b7f7cc2f7a2d3e1a67ba9a34b14632df9e080f9", size = 5094920, upload-time = "2026-03-13T13:53:29.329Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/53a1e9469331a23dcc400970a27a4caa3d9f6edbf5baab0260285238b884/fonttools-4.62.1-cp313-cp313-win32.whl", hash = "sha256:93c316e0f5301b2adbe6a5f658634307c096fd5aae60a5b3412e4f3e1728ab24", size = 2279928, upload-time = "2026-03-13T13:53:32.352Z" },
+    { url = "https://files.pythonhosted.org/packages/38/60/35186529de1db3c01f5ad625bde07c1f576305eab6d86bbda4c58445f721/fonttools-4.62.1-cp313-cp313-win_amd64.whl", hash = "sha256:7aa21ff53e28a9c2157acbc44e5b401149d3c9178107130e82d74ceb500e5056", size = 2330514, upload-time = "2026-03-13T13:53:34.991Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f0/2888cdac391807d68d90dcb16ef858ddc1b5309bfc6966195a459dd326e2/fonttools-4.62.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fa1d16210b6b10a826d71bed68dd9ec24a9e218d5a5e2797f37c573e7ec215ca", size = 2864442, upload-time = "2026-03-13T13:53:37.509Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b2/e521803081f8dc35990816b82da6360fa668a21b44da4b53fc9e77efcd62/fonttools-4.62.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:aa69d10ed420d8121118e628ad47d86e4caa79ba37f968597b958f6cceab7eca", size = 2410901, upload-time = "2026-03-13T13:53:40.55Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/8c3511ff06e53110039358dbbdc1a65d72157a054638387aa2ada300a8b8/fonttools-4.62.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd13b7999d59c5eb1c2b442eb2d0c427cb517a0b7a1f5798fc5c9e003f5ff782", size = 4999608, upload-time = "2026-03-13T13:53:42.798Z" },
+    { url = "https://files.pythonhosted.org/packages/28/63/cd0c3b26afe60995a5295f37c246a93d454023726c3261cfbb3559969bb9/fonttools-4.62.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8d337fdd49a79b0d51c4da87bc38169d21c3abbf0c1aa9367eff5c6656fb6dae", size = 4912726, upload-time = "2026-03-13T13:53:45.405Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b9/ac677cb07c24c685cf34f64e140617d58789d67a3dd524164b63648c6114/fonttools-4.62.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d241cdc4a67b5431c6d7f115fdf63335222414995e3a1df1a41e1182acd4bcc7", size = 4951422, upload-time = "2026-03-13T13:53:48.326Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/10/11c08419a14b85b7ca9a9faca321accccc8842dd9e0b1c8a72908de05945/fonttools-4.62.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c05557a78f8fa514da0f869556eeda40887a8abc77c76ee3f74cf241778afd5a", size = 5060979, upload-time = "2026-03-13T13:53:51.366Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3c/12eea4a4cf054e7ab058ed5ceada43b46809fce2bf319017c4d63ae55bb4/fonttools-4.62.1-cp314-cp314-win32.whl", hash = "sha256:49a445d2f544ce4a69338694cad575ba97b9a75fff02720da0882d1a73f12800", size = 2283733, upload-time = "2026-03-13T13:53:53.606Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/67/74b070029043186b5dd13462c958cb7c7f811be0d2e634309d9a1ffb1505/fonttools-4.62.1-cp314-cp314-win_amd64.whl", hash = "sha256:1eecc128c86c552fb963fe846ca4e011b1be053728f798185a1687502f6d398e", size = 2335663, upload-time = "2026-03-13T13:53:56.23Z" },
+    { url = "https://files.pythonhosted.org/packages/42/c5/4d2ed3ca6e33617fc5624467da353337f06e7f637707478903c785bd8e20/fonttools-4.62.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1596aeaddf7f78e21e68293c011316a25267b3effdaccaf4d59bc9159d681b82", size = 2947288, upload-time = "2026-03-13T13:53:59.397Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e9/7ab11ddfda48ed0f89b13380e5595ba572619c27077be0b2c447a63ff351/fonttools-4.62.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8f8fca95d3bb3208f59626a4b0ea6e526ee51f5a8ad5d91821c165903e8d9260", size = 2449023, upload-time = "2026-03-13T13:54:01.642Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/10/a800fa090b5e8819942e54e19b55fc7c21fe14a08757c3aa3ca8db358939/fonttools-4.62.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee91628c08e76f77b533d65feb3fbe6d9dad699f95be51cf0d022db94089cdc4", size = 5137599, upload-time = "2026-03-13T13:54:04.495Z" },
+    { url = "https://files.pythonhosted.org/packages/37/dc/8ccd45033fffd74deb6912fa1ca524643f584b94c87a16036855b498a1ed/fonttools-4.62.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f37df1cac61d906e7b836abe356bc2f34c99d4477467755c216b72aa3dc748b", size = 4920933, upload-time = "2026-03-13T13:54:07.557Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/e618adefb839598d25ac8136cd577925d6c513dc0d931d93b8af956210f0/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92bb00a947e666169c99b43753c4305fc95a890a60ef3aeb2a6963e07902cc87", size = 5016232, upload-time = "2026-03-13T13:54:10.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5f/9b5c9bfaa8ec82def8d8168c4f13615990d6ce5996fe52bd49bfb5e05134/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:bdfe592802ef939a0e33106ea4a318eeb17822c7ee168c290273cbd5fabd746c", size = 5042987, upload-time = "2026-03-13T13:54:13.569Z" },
+    { url = "https://files.pythonhosted.org/packages/90/aa/dfbbe24c6a6afc5c203d90cc0343e24bcbb09e76d67c4d6eef8c2558d7ba/fonttools-4.62.1-cp314-cp314t-win32.whl", hash = "sha256:b820fcb92d4655513d8402d5b219f94481c4443d825b4372c75a2072aa4b357a", size = 2348021, upload-time = "2026-03-13T13:54:16.98Z" },
+    { url = "https://files.pythonhosted.org/packages/13/6f/ae9c4e4dd417948407b680855c2c7790efb52add6009aaecff1e3bc50e8e/fonttools-4.62.1-cp314-cp314t-win_amd64.whl", hash = "sha256:59b372b4f0e113d3746b88985f1c796e7bf830dd54b28374cd85c2b8acd7583e", size = 2414147, upload-time = "2026-03-13T13:54:19.416Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ba/56147c165442cc5ba7e82ecf301c9a68353cede498185869e6e02b4c264f/fonttools-4.62.1-py3-none-any.whl", hash = "sha256:7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd", size = 1152647, upload-time = "2026-03-13T13:54:22.735Z" },
+]
+
+[package.optional-dependencies]
+woff = [
+    { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
+    { name = "brotlicffi", marker = "platform_python_implementation != 'CPython'" },
+    { name = "zopfli" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -592,7 +720,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -601,7 +728,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -610,7 +736,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -619,7 +744,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -741,6 +865,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -855,12 +988,103 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
+name = "prometheus-fastapi-instrumentator"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prometheus-client" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/6d/24d53033cf93826aa7857699a4450c1c67e5b9c710e925b1ed2b320c04df/prometheus_fastapi_instrumentator-7.1.0.tar.gz", hash = "sha256:be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e", size = 20220, upload-time = "2025-03-19T19:35:05.351Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/72/0824c18f3bc75810f55dacc2dd933f6ec829771180245ae3cc976195dec0/prometheus_fastapi_instrumentator-7.1.0-py3-none-any.whl", hash = "sha256:978130f3c0bb7b8ebcc90d35516a6fe13e02d2eb358c8f83887cdef7020c31e9", size = 19296, upload-time = "2025-03-19T19:35:04.323Z" },
 ]
 
 [[package]]
@@ -1064,6 +1288,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pydyf"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/ee/fb410c5c854b6a081a49077912a9765aeffd8e07cbb0663cfda310b01fb4/pydyf-0.12.1.tar.gz", hash = "sha256:fbd7e759541ac725c29c506612003de393249b94310ea78ae44cb1d04b220095", size = 17716, upload-time = "2025-12-02T14:52:14.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/11/47efe2f66ba848a107adfd490b508f5c0cedc82127950553dca44d29e6c4/pydyf-0.12.1-py3-none-any.whl", hash = "sha256:ea25b4e1fe7911195cb57067560daaa266639184e8335365cc3ee5214e7eaadc", size = 8028, upload-time = "2025-12-02T14:52:12.938Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1139,6 +1372,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/fb/dc2e8cb006e80b0020ed20d8649106fe4274e82d8e756ad3e24ade19c0df/pypdf-6.9.1.tar.gz", hash = "sha256:ae052407d33d34de0c86c5c729be6d51010bf36e03035a8f23ab449bca52377d", size = 5311551, upload-time = "2026-03-17T10:46:07.876Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/f4/75543fa802b86e72f87e9395440fe1a89a6d149887e3e55745715c3352ac/pypdf-6.9.1-py3-none-any.whl", hash = "sha256:f35a6a022348fae47e092a908339a8f3dc993510c026bb39a96718fc7185e89f", size = 333661, upload-time = "2026-03-17T10:46:06.286Z" },
+]
+
+[[package]]
+name = "pyphen"
+version = "0.17.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/56/e4d7e1bd70d997713649c5ce530b2d15a5fc2245a74ca820fc2d51d89d4d/pyphen-0.17.2.tar.gz", hash = "sha256:f60647a9c9b30ec6c59910097af82bc5dd2d36576b918e44148d8b07ef3b4aa3", size = 2079470, upload-time = "2025-01-20T13:18:36.296Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/1f/c2142d2edf833a90728e5cdeb10bdbdc094dde8dbac078cee0cf33f5e11b/pyphen-0.17.2-py3-none-any.whl", hash = "sha256:3a07fb017cb2341e1d9ff31b8634efb1ae4dc4b130468c7c39dd3d32e7c3affd", size = 2079358, upload-time = "2025-01-20T13:18:29.629Z" },
 ]
 
 [[package]]
@@ -1358,6 +1600,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
+    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+]
+
+[[package]]
 name = "s3transfer"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1470,6 +1737,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
+]
+
+[[package]]
+name = "tinyhtml5"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/1f/cfe2f6b30557c92b3f31d41707e09cef5c1efbd87392bc6c0430c46b0e4d/tinyhtml5-2.1.0.tar.gz", hash = "sha256:60a50ec3d938a37e491efa01af895853060943dcebb5627de5b10d188b338a67", size = 179242, upload-time = "2026-03-05T17:06:30.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/48/01695a036b695f83fea7aef6955d735db0f517b1c8e25ddb399ac0bdbcbf/tinyhtml5-2.1.0-py3-none-any.whl", hash = "sha256:6e11cfff38515834268daf89d5f85bbde0b6dd02e8d9e212d1385c2289b89f0a", size = 39686, upload-time = "2026-03-05T17:06:28.498Z" },
 ]
 
 [[package]]
@@ -1665,6 +1956,34 @@ wheels = [
 ]
 
 [[package]]
+name = "weasyprint"
+version = "68.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "cssselect2" },
+    { name = "fonttools", extra = ["woff"] },
+    { name = "pillow" },
+    { name = "pydyf" },
+    { name = "pyphen" },
+    { name = "tinycss2" },
+    { name = "tinyhtml5" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/3e/65c0f176e6fb5c2b0a1ac13185b366f727d9723541babfa7fa4309998169/weasyprint-68.1.tar.gz", hash = "sha256:d3b752049b453a5c95edb27ce78d69e9319af5a34f257fa0f4c738c701b4184e", size = 1542379, upload-time = "2026-02-06T15:04:11.203Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/dd/14eb73cea481ad8162d3b18a4850d4a84d6e804a22840cca207648532265/weasyprint-68.1-py3-none-any.whl", hash = "sha256:4dc3ba63c68bbbce3e9617cb2226251c372f5ee90a8a484503b1c099da9cf5be", size = 319789, upload-time = "2026-02-06T15:04:09.189Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
 name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1707,4 +2026,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "zopfli"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/4d/a8cc1768b2eda3c0c7470bf8059dcb94ef96d45dd91fc6edd29430d44072/zopfli-0.4.1.tar.gz", hash = "sha256:07a5cdc5d1aaa6c288c5d9f5a5383042ba743641abf8e2fd898dcad622d8a38e", size = 179001, upload-time = "2026-02-13T14:17:27.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/2f/1a7082e9163ae3703b27d571720bf3c954a02a9cf1fdce47c51e70639256/zopfli-0.4.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:4238d4d746d1095e29c9125490985e0c12ffd3654f54a24af551e2391e936d54", size = 291570, upload-time = "2026-02-13T14:17:12.556Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/4a1a88edf9fa0ce102703f38ab4dfb285b7cd2dde5389184264ec759e06e/zopfli-0.4.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fdfb7ce9f5de37a5b2f75dd2642fd7717956ef2a72e0387302a36d382440db07", size = 829437, upload-time = "2026-02-13T14:17:14.431Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/77/d231012ddcaac9d2e184bd7808e106a8a0048855912e2e1c902b3f383413/zopfli-0.4.1-cp310-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7bcee1b189d64ec33d1e05cfa1b6a1268c29329c382f6ca1bd6245b04925c57", size = 818542, upload-time = "2026-02-13T14:17:16.353Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/4e/9b23690c4ca14fbeae2a8f7f6b2006611bf4cd7d5bcb2d9e6c718bd4b0e9/zopfli-0.4.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:27823dc1161a4031d1c25925fd45d9868ec0cbc7692341830a7dcfa25063662c", size = 1778034, upload-time = "2026-02-13T14:17:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1b/51f7c28d4cde639cac4f5d47ff615548c1d9809f43cbacdd66eba5cd679d/zopfli-0.4.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5a4c22b6161f47f5bd34637dbaee6735abd287cd64e0d1ce28ef1871bf625f4b", size = 1863957, upload-time = "2026-02-13T14:17:19.259Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4d/1ef17017d38eabe7ae28f18ef0f16d48966cc23a5657e4555fff61704539/zopfli-0.4.1-cp310-abi3-win32.whl", hash = "sha256:a899eca405662a23ae75054affa3517a060362eae1185d3d791c86a50153c4dd", size = 82314, upload-time = "2026-02-13T14:17:20.795Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/806bc84b389c7d70051d7c9a0179cff52de8b9f8dc2fc25bcf0bca302986/zopfli-0.4.1-cp310-abi3-win_amd64.whl", hash = "sha256:84a31ba9edc921b1d3a4449929394a993888f32d70de3a3617800c428a947b9b", size = 102186, upload-time = "2026-02-13T14:17:21.622Z" },
 ]

--- a/deployment/docker-compose.dev.yml
+++ b/deployment/docker-compose.dev.yml
@@ -16,7 +16,7 @@ services:
       - ./services/db/init.sql:/docker-entrypoint-initdb.d/init-dbs.sql
 
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}" ]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -38,20 +38,7 @@ services:
       - ./services/mongo/init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
       - ./services/mongo/templates:/docker-entrypoint-initdb.d/templates:ro
     healthcheck:
-      test:
-        [
-          "CMD",
-          "mongo",
-          "--quiet",
-          "-u",
-          "${MONGO_ROOT_USER}",
-          "-p",
-          "${MONGO_ROOT_PASSWORD}",
-          "--authenticationDatabase",
-          "admin",
-          "--eval",
-          "db.adminCommand('ping')",
-        ]
+      test: [ "CMD", "mongo", "--quiet", "-u", "${MONGO_ROOT_USER}", "-p", "${MONGO_ROOT_PASSWORD}", "--authenticationDatabase", "admin", "--eval", "db.adminCommand('ping')" ]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -59,7 +46,9 @@ services:
   garage:
     image: dxflrs/garage:76592723deb9285a071320c40842f6be61e924fd
     container_name: sl-garage-dev
-    command: /garage server --single-node --default-bucket
+    restart: unless-stopped
+    entrypoint: [ "/garage" ]
+    command: [ "server", "--single-node", "--default-bucket" ]
     environment:
       GARAGE_RPC_SECRET: ${GARAGE_RPC_SECRET}
       GARAGE_DEFAULT_ACCESS_KEY: ${GARAGE_ACCESS_KEY_ID}
@@ -69,10 +58,10 @@ services:
       - "3900:3900"
       - "3901:3901"
     volumes:
-      - ./services/garage/garage.template.toml:/etc/garage.toml:ro
+      - ./services/garage/garage.toml:/etc/garage.toml:ro
       - garage_data:/var/lib/garage
     healthcheck:
-      test: ["CMD", "/garage", "-c", "/etc/garage.toml", "status"]
+      test: [ "CMD", "/garage", "-c", "/etc/garage.toml", "status" ]
       interval: 15s
       timeout: 10s
       retries: 10
@@ -96,7 +85,7 @@ services:
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
     healthcheck:
-      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      test: [ "CMD", "rabbitmq-diagnostics", "-q", "ping" ]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -145,11 +134,7 @@ services:
       KC_DB_POOL_MAX_SIZE: 10
 
     healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "exec 3<>/dev/tcp/127.0.0.1/9000; echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost:8080\\r\\nConnection: close\\r\\n\\r\\n' >&3;cat <&3 | grep -q '\"status\": \"UP\"' && exit 0 || exit 1",
-        ]
+      test: [ "CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/9000; echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost:8080\\r\\nConnection: close\\r\\n\\r\\n' >&3;cat <&3 | grep -q '\"status\": \"UP\"' && exit 0 || exit 1" ]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -208,7 +193,7 @@ services:
     volumes:
       - ../api/src:/app/src:ro
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8000/health"]
+      test: [ "CMD", "curl", "-sf", "http://localhost:8000/health" ]
       interval: 15s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
- **First version with mock data (SL-281)**
This add a modular structure to generate pdf reports from html.
It works by defining a section with a html fragment and them using a builder to stitch all fragments and css style together.
The collectors are the bridge between the data collection that will be then used to populate the html.
Data is only collected once to reduce system load.
