### PR TITLE
Hotfix missing env vars

### DIFF
--- a/.github/workflows/build-release-images.yml
+++ b/.github/workflows/build-release-images.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    environment: production
     strategy:
       fail-fast: false
       matrix:
@@ -58,4 +59,4 @@ jobs:
             ${{ steps.tags.outputs.image }}:${{ steps.tags.outputs.sha_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: ${{ matrix.name == 'web' && format('VITE_API_URL={0}\nVITE_KEYCLOAK_URL={1}\nVITE_BASE_PATH={2}\nVITE_WEB_URL={3}', secrets.VITE_API_URL, secrets.VITE_KEYCLOAK_URL, secrets.VITE_BASE_PATH, secrets.VITE_WEB_URL) || '' }}
+          build-args: ${{ matrix.name == 'web' && format('VITE_API_URL={0}\nVITE_KEYCLOAK_URL={1}\nVITE_BASE_PATH={2}\nVITE_WEB_URL={3}', vars.API_URL, vars.KEYCLOAK_URL, vars.VITE_BASE_PATH, vars.WEB_URL) || '' }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,14 +89,18 @@ jobs:
           GARAGE_CONTENT_PREFIX: ${{ vars.GARAGE_CONTENT_PREFIX }}
           GARAGE_LOGOS_PREFIX: ${{ vars.GARAGE_LOGOS_PREFIX }}
           PUBLIC_BASE_URL: ${{ vars.PUBLIC_BASE_URL }}
+          KC_HTTP_RELATIVE_PATH: ${{ vars.KC_HTTP_RELATIVE_PATH }}
+          VITE_BASE_PATH: ${{ vars.VITE_BASE_PATH }}
           KC_HOSTNAME: ${{ vars.KC_HOSTNAME }}
           KC_HOSTNAME_URL: ${{ vars.KC_HOSTNAME_URL }}
           KEYCLOAK_INTERNAL_URL: ${{ vars.KEYCLOAK_INTERNAL_URL }}
+          KEYCLOAK_URL: ${{ vars.KEYCLOAK_URL }}
           API_INTERNAL_URL: ${{ vars.API_INTERNAL_URL }}
           API_URL: ${{ vars.API_URL }}
           WEB_URL: ${{ vars.WEB_URL }}
           KEYCLOAK_ISSUER_URL: ${{ vars.KEYCLOAK_ISSUER_URL }}
           NGINX_PORT: ${{ vars.NGINX_PORT }}
+          SERVER_PORT: ${{ vars.SERVER_PORT }}
           TLS_CERT_FILE: ${{ vars.TLS_CERT_FILE }}
           TLS_KEY_FILE: ${{ vars.TLS_KEY_FILE }}
           DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
@@ -136,13 +140,17 @@ jobs:
             printf 'CLIENT_SECRET=%s\n'            "$CLIENT_SECRET"
             printf 'KC_HOSTNAME=%s\n'              "$KC_HOSTNAME"
             printf 'KC_HOSTNAME_URL=%s\n'          "$KC_HOSTNAME_URL"
+            printf 'KC_HTTP_RELATIVE_PATH=%s\n'    "$KC_HTTP_RELATIVE_PATH"
             printf 'KEYCLOAK_INTERNAL_URL=%s\n'    "$KEYCLOAK_INTERNAL_URL"
+            printf 'KEYCLOAK_URL=%s\n'             "$KEYCLOAK_URL"
             printf 'API_INTERNAL_URL=%s\n'         "$API_INTERNAL_URL"
             printf 'PUBLIC_BASE_URL=%s\n'          "$PUBLIC_BASE_URL"
+            printf 'VITE_BASE_PATH=%s\n'           "$VITE_BASE_PATH"
             printf 'API_URL=%s\n'                  "$API_URL"
             printf 'WEB_URL=%s\n'                  "$WEB_URL"
             printf 'KEYCLOAK_ISSUER_URL=%s\n'      "$KEYCLOAK_ISSUER_URL"
             printf 'NGINX_PORT=%s\n'               "$NGINX_PORT"
+            printf 'SERVER_PORT=%s\n'              "$SERVER_PORT"
             printf 'TLS_CERT_FILE=%s\n'            "$TLS_CERT_FILE"
             printf 'TLS_KEY_FILE=%s\n'             "$TLS_KEY_FILE"
             printf 'DOCKERHUB_USERNAME=%s\n'       "$DOCKERHUB_USERNAME"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve environment variable management and standardize the use of variables across build and deployment pipelines. The main changes involve switching from secrets to environment variables, and ensuring all necessary variables are available for both build and deployment jobs.

**Workflow variable management improvements:**

* Switched the `build-args` for the `web` image in `.github/workflows/build-release-images.yml` to use workflow `vars` instead of `secrets`, ensuring consistency and easier management of environment-specific values.
* Added the `environment: production` specification to the `build-and-push` job in `.github/workflows/build-release-images.yml` to explicitly set the deployment environment.

**Expanded environment variable support in deployment:**

* Added several new environment variables (such as `KC_HTTP_RELATIVE_PATH`, `VITE_BASE_PATH`, `KEYCLOAK_URL`, and `SERVER_PORT`) to the deployment job in `.github/workflows/cd.yml`, making them available during deployment and configuration.
* Updated the deployment configuration script to include the new variables, ensuring they are written to the environment file used during deployment.