### PR TITLE
Fix sonar artifact download path and commit context

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -23,7 +23,8 @@ jobs:
           workflow: ci-api.yml
           workflow_conclusion: success
           name: api-coverage
-          path: api/
+          path: .
+          commit: ${{ github.sha }}
           if_no_artifact_found: warn
 
       - uses: SonarSource/sonarqube-scan-action@v5


### PR DESCRIPTION
Download coverage from exact commit being scanned (github.sha) instead of
latest ci-api run. Preserves artifact directory structure by downloading
to root instead of api/ subdirectory.
