### PR TITLE
Fix: Moved keycloak provider into @providers.tsx

### DIFF
--- a/web/src/lib/providers.tsx
+++ b/web/src/lib/providers.tsx
@@ -1,22 +1,45 @@
+import { ReactKeycloakProvider } from '@react-keycloak/web'
 import { NuqsAdapter } from 'nuqs/adapters/tanstack-router'
 import { Toaster } from "@/components/ui/sonner";
 import { ConfirmProvider } from "@/components/ui/confirm-modal";
 import { ThemeProvider } from "next-themes";
+import keycloak from "@/keycloak";
 
-export function Providers({ children }: { children: React.ReactNode }) {
+const isSecureContext = globalThis.isSecureContext || globalThis.location.hostname === 'localhost';
+
+const initOptions: Keycloak.KeycloakInitOptions = {
+    onLoad: "login-required",
+    pkceMethod: isSecureContext ? "S256" : undefined,
+    responseMode: "query",
+    checkLoginIframe: false,
+};
+
+export function Providers({
+    children,
+    onKeycloakEvent,
+}: {
+    children: React.ReactNode;
+    onKeycloakEvent?: (event: string, error: unknown) => void;
+}) {
     return (
-        <ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            themes={['light', 'dark', 'deuteranopia', 'protanopia', 'tritanopia', 'system']}
+        <ReactKeycloakProvider
+            authClient={keycloak}
+            initOptions={initOptions}
+            onEvent={onKeycloakEvent}
         >
-            <NuqsAdapter>
-                <ConfirmProvider>
-                    {children}
-                </ConfirmProvider>
-                <Toaster />
-            </NuqsAdapter>
-        </ThemeProvider>
+            <ThemeProvider
+                attribute="class"
+                defaultTheme="system"
+                enableSystem
+                themes={['light', 'dark', 'deuteranopia', 'protanopia', 'tritanopia', 'system']}
+            >
+                <NuqsAdapter>
+                    <ConfirmProvider>
+                        {children}
+                    </ConfirmProvider>
+                    <Toaster />
+                </NuqsAdapter>
+            </ThemeProvider>
+        </ReactKeycloakProvider>
     );
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import ReactDOM from 'react-dom/client'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
-import { ReactKeycloakProvider } from '@react-keycloak/web'
 
 // Import the generated route tree
 import { routeTree } from './routeTree.gen'
@@ -10,15 +9,6 @@ import keycloak from "./keycloak"
 import { EmailEntry } from './components/EmailEntry'
 import { SimulationOops } from './components/SimulationOops'
 import { appBasePath, isAppRoute } from './lib/app-path'
-
-const isSecureContext = globalThis.isSecureContext || globalThis.location.hostname === 'localhost';
-
-const initOptions: Keycloak.KeycloakInitOptions = {
-  onLoad: "login-required",
-  pkceMethod: isSecureContext ? "S256" : undefined,
-  responseMode: "query",
-  checkLoginIframe: false,
-};
 
 // Create a new router instance
 const router = createRouter({
@@ -88,13 +78,11 @@ const App = () => {
     <>
       <AppLoader visible={isLoading} label="Connecting to SecureLearning…" />
       {!isLoading && (
-        <ReactKeycloakProvider authClient={keycloak} initOptions={initOptions} onEvent={onEvent}>
-          <ErrorBoundary>
-            <Providers>
-              <RouterProvider router={router} />
-            </Providers>
-          </ErrorBoundary>
-        </ReactKeycloakProvider>
+        <ErrorBoundary>
+          <Providers onKeycloakEvent={onEvent}>
+            <RouterProvider router={router} />
+          </Providers>
+        </ErrorBoundary>
       )}
     </>
   )


### PR DESCRIPTION
This pull request refactors how authentication is integrated into the application by moving the `ReactKeycloakProvider` and its configuration from `main.tsx` into the `Providers` component. This centralizes authentication logic and makes the provider easier to manage and extend. The initialization logic for Keycloak is now encapsulated within `Providers`, and an optional `onKeycloakEvent` callback can be passed down for event handling.

**Authentication integration refactor:**

* Moved the `ReactKeycloakProvider` and Keycloak initialization options from `main.tsx` to the `Providers` component in `providers.tsx`, centralizing authentication logic. (`[[1]](diffhunk://#diff-31185084586cdc563b5a7159b953255407719adc390caa58cee77998ec82fe85R1-R29)`, `[[2]](diffhunk://#diff-20da45cb8443d5036aea448ba7f0379ca304c43e1136ca82d9d43d731a37311eL4)`, `[[3]](diffhunk://#diff-20da45cb8443d5036aea448ba7f0379ca304c43e1136ca82d9d43d731a37311eL14-L22)`, `[[4]](diffhunk://#diff-20da45cb8443d5036aea448ba7f0379ca304c43e1136ca82d9d43d731a37311eL91-L97)`)
* Updated the `Providers` component to accept an optional `onKeycloakEvent` callback for handling Keycloak events, and to wrap all children (including theming and UI providers) within the authentication context. (`[[1]](diffhunk://#diff-31185084586cdc563b5a7159b953255407719adc390caa58cee77998ec82fe85R1-R29)`, `[[2]](diffhunk://#diff-31185084586cdc563b5a7159b953255407719adc390caa58cee77998ec82fe85R43)`, `[[3]](diffhunk://#diff-20da45cb8443d5036aea448ba7f0379ca304c43e1136ca82d9d43d731a37311eL91-L97)`)

These changes improve maintainability and make it easier to manage authentication across the application.